### PR TITLE
Upgrade bootstrap to version 3.4.1

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -1,7 +1,7 @@
 <Project>
 	<PropertyGroup>
 		<VersionMajor>0</VersionMajor>
-		<VersionMinor>8</VersionMinor>
+		<VersionMinor>9</VersionMinor>
 		<VersionPatch>0</VersionPatch>
 		<VersionQuality></VersionQuality>
 		<VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/sample/SkyApm.Sample.AspNet/packages.config
+++ b/sample/SkyApm.Sample.AspNet/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="bootstrap" version="3.3.7" targetFramework="net45" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="Grpc" version="1.12.0" targetFramework="net45" />
   <package id="Grpc.Core" version="1.12.0" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance


### Bug fix
- Bug description.
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/
