### PR TITLE
Agent performance optimization

### DIFF
--- a/sample/SkyApm.Sample.Backend/appsettings.Development.json
+++ b/sample/SkyApm.Sample.Backend/appsettings.Development.json
@@ -3,12 +3,12 @@
     "IncludeScopes": false,
     "Debug": {
       "LogLevel": {
-        "Default": "Debug"
+        "Default": "Warning"
       }
     },
     "Console": {
       "LogLevel": {
-        "Default": "Debug"
+        "Default": "Warning"
       }
     }
   }

--- a/sample/SkyApm.Sample.Backend/skyapm.json
+++ b/sample/SkyApm.Sample.Backend/skyapm.json
@@ -20,8 +20,8 @@
       "BatchSize": 3000,
       "gRPC": {
         "Servers": "localhost:11800",
-        "Timeout": 10000,
-        "ConnectTimeout": 10000,
+        "Timeout": 100000,
+        "ConnectTimeout": 100000,
         "ReportTimeout": 600000
       }
     }

--- a/src/SkyApm.Core/Diagnostics/PropertyAttribute.cs
+++ b/src/SkyApm.Core/Diagnostics/PropertyAttribute.cs
@@ -16,6 +16,8 @@
  *
  */
 
+using AspectCore.Extensions.Reflection;
+
 namespace SkyApm.Diagnostics
 {
     public class PropertyAttribute : ParameterBinder
@@ -30,8 +32,8 @@ namespace SkyApm.Diagnostics
             }
 
             var property = value.GetType().GetProperty(Name);
-            
-            return property?.GetValue(value);
+
+            return property?.GetReflector()?.GetValue(value);
         }
     }
 }

--- a/src/SkyApm.Core/Diagnostics/TracingDiagnosticMethod.cs
+++ b/src/SkyApm.Core/Diagnostics/TracingDiagnosticMethod.cs
@@ -19,21 +19,22 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using AspectCore.Extensions.Reflection;
 
 namespace SkyApm.Diagnostics
 {
     internal class TracingDiagnosticMethod
     {
-        private readonly MethodInfo _method;
         private readonly ITracingDiagnosticProcessor _tracingDiagnosticProcessor;
         private readonly string _diagnosticName;
         private readonly IParameterResolver[] _parameterResolvers;
+        private readonly MethodReflector _reflector;
 
         public TracingDiagnosticMethod(ITracingDiagnosticProcessor tracingDiagnosticProcessor, MethodInfo method,
             string diagnosticName)
         {
             _tracingDiagnosticProcessor = tracingDiagnosticProcessor;
-            _method = method;
+            _reflector = method.GetReflector();
             _diagnosticName = diagnosticName;
             _parameterResolvers = GetParameterResolvers(method).ToArray();
         }
@@ -51,7 +52,7 @@ namespace SkyApm.Diagnostics
                 args[i] = _parameterResolvers[i].Resolve(value);
             }
 
-            _method.Invoke(_tracingDiagnosticProcessor, args);
+            _reflector.Invoke(_tracingDiagnosticProcessor, args);
         }
 
         private static IEnumerable<IParameterResolver> GetParameterResolvers(MethodInfo methodInfo)

--- a/src/SkyApm.Core/SkyApm.Core.csproj
+++ b/src/SkyApm.Core/SkyApm.Core.csproj
@@ -12,6 +12,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AspectCore.Extensions.Reflection" Version="1.2.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues
https://github.com/SkyAPM/SkyAPM-dotnet/issues/156
___
### New feature or improvement
- Describe the details and related test reports.

We used ConcurrentQueue to cache the traceSegment that was not sent to the collector. In order to avoid the cache is too large to cause OOM problems in the application, we limit the size of the ConcurrentQueue.
```
 public bool Dispatch(SegmentContext segmentContext)
 {
      if (_config.QueueSize < _segmentQueue.Count || _cancellation.IsCancellationRequested)
          return false;

        // other code

        return true;
}
```

Due to a bug in `ConcurrentQueue` itself in the .NET Core BCL, calling the `Count` function of ConcurrentQueue can cause unexpected poor performance (https://github.com/dotnet/corefx/issues/29759 ). The dotnet team promised that this issue will be fixed in the .NET Core 3.0 release, but almost all users are still using the .NET Core 2.x. We use atomic operation counts to avoid calling the ConcurrentQueue `Count` function to solve performance problems