### PR TITLE
fix(Agent.AspNet): fix DelegatingHandler while using with HttpClientFactory

### DIFF
--- a/sample/SkyApm.Sample.AspNet/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.AspNet/Controllers/ValuesController.cs
@@ -5,13 +5,26 @@ using SkyApm.Agent.AspNet;
 
 namespace SkyApm.Sample.AspNet.Controllers
 {
+    [RoutePrefix("api/values")]
     public class ValuesController : ApiController
     {
+        [HttpGet]
         public async Task<IHttpActionResult> Get()
         {
             var httpClient = new HttpClient(new HttpTracingHandler());
             var values = await httpClient.GetStringAsync("http://localhost:5001/api/values");
             return Json(values);
+        }
+
+        [HttpGet]
+        [Route("{id:int}")]
+        public async Task<string> Get(int id)
+        {
+            var client = HttpClientFactory.Create(new HttpTracingHandler(null));
+            Task.WhenAll(client.GetAsync("http://localhost:5002/api/delay/2000"),
+                client.GetAsync("http://localhost:5002/api/values"),
+                client.GetAsync("http://localhost:5002/api/delay/200"));
+            return await client.GetStringAsync("http://localhost:5002/api/delay/100");
         }
     }
 }

--- a/src/SkyApm.Agent.AspNet/HttpTracingHandler.cs
+++ b/src/SkyApm.Agent.AspNet/HttpTracingHandler.cs
@@ -26,20 +26,38 @@ using System.Threading.Tasks;
 using CommonServiceLocator;
 using SkyApm.Tracing;
 using SkyApm.Tracing.Segments;
-using SpanLayer = SkyApm.Tracing.Segments.SpanLayer;
 
 namespace SkyApm.Agent.AspNet
 {
     public class HttpTracingHandler : DelegatingHandler
     {
+        /// <summary>
+        /// If you are passing this delegating handler to <see cref="HttpClientFactory.Create"/> method, please pass a `null` in constructor as innerHandler.
+        /// if you are passing it in <see cref="HttpClient"/> constructor, just use it's non-parameter constructor.
+        /// as follow:
+        /// <code>var httpClient = HttpClientFactory.Create(new HttpTracingHandler(null))</code>
+        /// or
+        /// <code>var httpClient = new HttpClient(new HttpTracingHandler())</code>
+        /// </summary>
         public HttpTracingHandler()
             : this(new HttpClientHandler())
         {
         }
 
+        /// <summary>
+        /// If you are passing this delegating handler to <see cref="HttpClientFactory.Create"/> method, please pass a `null` in constructor as innerHandler.
+        /// if you are passing it in <see cref="HttpClient"/> constructor, just use it's non-parameter constructor.
+        /// as follow:
+        /// <code>var httpClient = HttpClientFactory.Create(new HttpTracingHandler(null))</code>
+        /// or
+        /// <code>var httpClient = new HttpClient(new HttpTracingHandler())</code>
+        /// </summary>
         public HttpTracingHandler(HttpMessageHandler innerHandler)
         {
-            InnerHandler = innerHandler;
+            if (innerHandler != null)
+            {
+                InnerHandler = innerHandler;
+            }
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,


### PR DESCRIPTION
fix DelegatingHandler while using with HttpClientFactory.

Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#199
___
### Bug fix

The `HttpClientFactory.Create` method whould pass the HttpClientHandler instance in method body.

```
    public static HttpClient Create(params DelegatingHandler[] handlers)
    {
      return HttpClientFactory.Create((HttpMessageHandler) new HttpClientHandler(), handlers);
    }
```