### PR TITLE
Support ignore path feature

### DIFF
--- a/sample/SkyApm.Sample.Backend/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.Backend/Controllers/ValuesController.cs
@@ -23,5 +23,11 @@ namespace SkyApm.Sample.Backend.Controllers
         {
             return "value";
         }
+
+        [HttpGet("ignore")]
+        public string Ignore()
+        {
+            return "ignore";
+        }
     } 
 }

--- a/sample/SkyApm.Sample.Frontend/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.Frontend/Controllers/ValuesController.cs
@@ -73,6 +73,13 @@ namespace SkyApm.Sample.Frontend.Controllers
             return Ok(message);
         }
 
+        [HttpGet("ignore")]
+        public async Task<IActionResult> Ignore()
+        {
+            var message = await new HttpClient().GetStreamAsync("http://localhost:5002/api/values/ignore");
+            return Ok(message);
+        }
+
 #if NETCOREAPP2_1
 #else
         [HttpGet("greeter/grpc-net")]

--- a/sample/SkyApm.Sample.Frontend/skyapm.json
+++ b/sample/SkyApm.Sample.Frontend/skyapm.json
@@ -7,7 +7,8 @@
     ],
     "Sampling": {
       "SamplePer3Secs": -1,
-      "Percentage": -1.0
+      "Percentage": -1.0,
+      "IgnorePaths": ["**/ignore"]
     },
     "Logging": {
       "Level": "Information",

--- a/src/SkyApm.Abstractions/Config/SamplingConfig.cs
+++ b/src/SkyApm.Abstractions/Config/SamplingConfig.cs
@@ -16,6 +16,8 @@
  *
  */
 
+using System.Collections.Generic;
+
 namespace SkyApm.Config
 {
     [Config("SkyWalking", "Sampling")]
@@ -24,5 +26,7 @@ namespace SkyApm.Config
         public int SamplePer3Secs { get; set; } = -1;
 
         public double Percentage { get; set; } = -1d;
+
+        public List<string> IgnorePaths { get; set; }
     }
 }

--- a/src/SkyApm.Abstractions/Config/SamplingConfig.cs
+++ b/src/SkyApm.Abstractions/Config/SamplingConfig.cs
@@ -27,6 +27,10 @@ namespace SkyApm.Config
 
         public double Percentage { get; set; } = -1d;
 
+        /// <summary>
+        /// Paths to ignore, support wildchar match.
+        /// Usage: a/b/c => a/b/c, a/* => a/b, a/** => a/b/c/d, a/?/c => a/b/c
+        /// </summary>
         public List<string> IgnorePaths { get; set; }
     }
 }

--- a/src/SkyApm.Agent.AspNet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.AspNet/Extensions/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ namespace SkyApm.Agent.AspNet.Extensions
             services.AddSingleton<ISamplingInterceptor>(p => p.GetService<SimpleCountSamplingInterceptor>());
             services.AddSingleton<IExecutionService>(p => p.GetService<SimpleCountSamplingInterceptor>());
             services.AddSingleton<ISamplingInterceptor, RandomSamplingInterceptor>();
+            services.AddSingleton<ISamplingInterceptor, IgnorePathSamplingInterceptor>();
 
             services.AddSingleton<ISegmentReporter, SegmentReporter>();
             services.AddSingleton<ICLRStatsReporter, CLRStatsReporter>();

--- a/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ISamplingInterceptor>(p => p.GetService<SimpleCountSamplingInterceptor>());
             services.AddSingleton<IExecutionService>(p => p.GetService<SimpleCountSamplingInterceptor>());
             services.AddSingleton<ISamplingInterceptor, RandomSamplingInterceptor>();
+            services.AddSingleton<ISamplingInterceptor, IgnorePathSamplingInterceptor>();
             return services;
         }
 

--- a/src/SkyApm.Core/Common/FastPathMatcher.cs
+++ b/src/SkyApm.Core/Common/FastPathMatcher.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SkyWalking.Common
+{
+    internal class FastPathMatcher
+    {
+        public static bool Match(string pattern, string path)
+        {
+            if (path == null) return false;
+            return NormalMatch(pattern, 0, path, 0);
+        }
+
+        private static bool NormalMatch(string pat, int p, string str, int s)
+        {
+            while (p < pat.Length)
+            {
+                char pc = pat[p];
+                char sc = SafeCharAt(str, s);
+
+                // Got * in pattern, enter the wildcard mode.
+                //            ↓        ↓
+                // pattern: a/*      a/*
+                //            ↓        ↓
+                // string:  a/bcd    a/
+                if (pc == '*')
+                {
+                    p++;
+                    // Got * in pattern again, enter the multi-wildcard mode.
+                    //             ↓        ↓
+                    // pattern: a/**     a/**
+                    //            ↓        ↓
+                    // string:  a/bcd    a/
+                    if (SafeCharAt(pat, p) == '*')
+                    {
+                        p++;
+                        // Enter the multi-wildcard mode.
+                        //              ↓        ↓
+                        // pattern: a/**     a/**
+                        //            ↓        ↓
+                        // string:  a/bcd    a/
+                        return MultiWildcardMatch(pat, p, str, s);
+                    }
+                    else
+                    {
+                        // Enter the wildcard mode.
+                        //             ↓
+                        // pattern: a/*
+                        //            ↓
+                        // string:  a/bcd
+                        return WildcardMatch(pat, p, str, s);
+                    }
+                }
+
+                // Matching ? for non-'/' char, or matching the same chars.
+                //            ↓        ↓       ↓
+                // pattern: a/?/c    a/b/c    a/b
+                //            ↓        ↓       ↓
+                // string:  a/b/c    a/b/d    a/d
+                if ((pc == '?' && sc != 0 && sc != '/') || pc == sc)
+                {
+                    s++;
+                    p++;
+                    continue;
+                }
+
+                // Not matched.
+                //            ↓
+                // pattern: a/b
+                //            ↓
+                // string:  a/c
+                return false;
+            }
+
+            return s == str.Length;
+        }
+
+        private static bool WildcardMatch(string pat, int p, string str, int s)
+        {
+            char pc = SafeCharAt(pat, p);
+
+            while (true)
+            {
+                char sc = SafeCharAt(str, s);
+
+                if (sc == '/')
+                {
+                    // Both of pattern and string '/' matched, exit wildcard mode.
+                    //             ↓
+                    // pattern: a/*/
+                    //              ↓
+                    // string:  a/bc/
+                    if (pc == sc)
+                    {
+                        return NormalMatch(pat, p + 1, str, s + 1);
+                    }
+
+                    // Not matched string in current path part.
+                    //             ↓        ↓
+                    // pattern: a/*      a/*d
+                    //              ↓        ↓
+                    // string:  a/bc/    a/bc/
+                    return false;
+                }
+
+                // Try to enter normal mode, if not matched, increasing pointer of string and try again.
+                if (!NormalMatch(pat, p, str, s))
+                {
+                    // End of string, not matched.
+                    if (s >= str.Length)
+                    {
+                        return false;
+                    }
+
+                    s++;
+                    continue;
+                }
+
+                // Matched in next normal mode.
+                return true;
+            }
+        }
+
+        private static bool MultiWildcardMatch(string pat, int p, string str, int s)
+        {
+            // End of pattern, just check the end of string is '/' quickly.
+            if (p >= pat.Length && s < str.Length)
+            {
+                return str[str.Length - 1] != '/';
+            }
+
+            while (true)
+            {
+                // Try to enter normal mode, if not matched, increasing pointer of string and try again.
+                if (!NormalMatch(pat, p, str, s))
+                {
+                    // End of string, not matched.
+                    if (s >= str.Length)
+                    {
+                        return false;
+                    }
+
+                    s++;
+                    continue;
+                }
+
+                return true;
+            }
+        }
+
+        private static char SafeCharAt(string value, int index)
+        {
+            if (index >= value.Length)
+            {
+                return (char)0;
+            }
+
+            return value[index];
+        }
+    }
+}

--- a/src/SkyApm.Core/Sampling/IgnorePathSamplingInterceptor.cs
+++ b/src/SkyApm.Core/Sampling/IgnorePathSamplingInterceptor.cs
@@ -1,0 +1,40 @@
+﻿using SkyApm.Config;
+using SkyApm.Tracing;
+using SkyWalking.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SkyApm.Sampling
+{
+    public class IgnorePathSamplingInterceptor : ISamplingInterceptor
+    {
+        private readonly bool _sample_on;
+        private readonly List<string> _ignorePaths;
+
+        public int Priority => int.MinValue + 998;
+
+        public IgnorePathSamplingInterceptor(IConfigAccessor configAccessor)
+        {
+            var ignorePaths = configAccessor.Get<SamplingConfig>().IgnorePaths;
+            _sample_on = ignorePaths?.Count > 0;
+            if(_sample_on)
+            {
+                _ignorePaths = ignorePaths;
+            }
+        }
+
+        public bool Invoke(SamplingContext samplingContext, Sampler next)
+        {
+            if(!_sample_on) return next(samplingContext);
+
+            foreach (var pattern in _ignorePaths)
+            {
+                if (FastPathMatcher.Match(pattern, samplingContext.OperationName))
+                    return false;
+            }
+
+            return next(samplingContext);
+        }
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

___
### New feature or improvement
- Support ignore path feature(#332 ), usage is similar to the java agent ignore plugin.

- Match Rules

Symbol | Desc
-- | --
`?` | match any single char
`*` | match 0 or more chars
`**` | match 0 or more directories

- Match Examples

Path | Desc
-- | --
/app/*.x |  matches all files with `.x` suffix under `app` path
/app/p?ttern | matches `/app/pattern` and `/app/pXttern`, but not `/app/pttern`
/**/example | matches ` /app/example`, `/app/foo/example`, `/example`


