### PR TITLE
feature: Support stop header propagation on specific path

### DIFF
--- a/sample/SkyApm.Sample.Backend/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.Backend/Controllers/ValuesController.cs
@@ -29,5 +29,11 @@ namespace SkyApm.Sample.Backend.Controllers
         {
             return "ignore";
         }
+
+        [HttpGet("StopPropagation")]
+        public string StopPropagation()
+        {
+            return "stop propagation";
+        }
     } 
 }

--- a/sample/SkyApm.Sample.Frontend/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.Frontend/Controllers/ValuesController.cs
@@ -80,6 +80,13 @@ namespace SkyApm.Sample.Frontend.Controllers
             return Ok(message);
         }
 
+        [HttpGet("StopPropagation")]
+        public async Task<IActionResult> StopPropagation()
+        {
+            var message = await new HttpClient().GetStreamAsync("http://localhost:5002/api/values/stoppropagation");
+            return Ok(message);
+        }
+
 #if NETCOREAPP2_1
 #else
         [HttpGet("greeter/grpc-net")]

--- a/sample/SkyApm.Sample.Frontend/skyapm.json
+++ b/sample/SkyApm.Sample.Frontend/skyapm.json
@@ -25,6 +25,11 @@
         "ConnectTimeout": 100000,
         "ReportTimeout": 600000
       }
+    },
+    "Component": {
+      "HttpClient": {
+        "StopHeaderPropagationPaths": [ "**/localhost:5002/api/values/stoppropagation" ]
+      }
     }
   }
 }

--- a/src/SkyApm.Core/Common/FastPathMatcher.cs
+++ b/src/SkyApm.Core/Common/FastPathMatcher.cs
@@ -18,7 +18,7 @@
 
 namespace SkyApm.Common
 {
-    internal class FastPathMatcher
+    public class FastPathMatcher
     {
         public static bool Match(string pattern, string path)
         {

--- a/src/SkyApm.Diagnostics.HttpClient/Config/HttpClientDiagnosticConfig.cs
+++ b/src/SkyApm.Diagnostics.HttpClient/Config/HttpClientDiagnosticConfig.cs
@@ -1,0 +1,17 @@
+﻿using SkyApm.Config;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SkyApm.Diagnostics.HttpClient.Config
+{
+    [Config("SkyWalking", "Component", "HttpClient")]
+    public class HttpClientDiagnosticConfig
+    {
+        /// <summary>
+        /// Stop header propagation on specific paths, path support wildchar match.
+        /// Usage: a/b/c => a/b/c, a/* => a/b, a/** => a/b/c/d, a/?/c => a/b/c
+        /// </summary>
+        public List<string> StopHeaderPropagationPaths { get; set; }
+    }
+}

--- a/test/SkyApm.Core.Tests/FastPathMatcherTests.cs
+++ b/test/SkyApm.Core.Tests/FastPathMatcherTests.cs
@@ -1,0 +1,59 @@
+﻿using SkyApm.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SkyApm.Core.Tests
+{
+    public class FastPathMatcherTests
+    {
+        [Fact]
+        public void Match_WithCorrectPattern_ShouldSuccess()
+        {
+            var path = "http://localhost:5001/api/values";
+
+            var pattern = "http://localhost:5001/api/values";
+            var result = FastPathMatcher.Match(pattern, path);
+            Assert.True(result);
+
+            pattern = "*//localhost:5001/api/values";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.True(result);
+
+            pattern = "**/localhost:5001/api/values";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.True(result);
+
+            pattern = "**/localhost:5001/**";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.True(result);
+
+            pattern = "**localhost:5001**";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Match_WithWrongPattern_ShouldFail()
+        {
+            var path = "http://localhost:5001/api/values";
+
+            var pattern = "localhost:5001/api/values";
+            var result = FastPathMatcher.Match(pattern, path);
+            Assert.False(result);
+
+            pattern = "//localhost:5001/api/values";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.False(result);
+
+            pattern = "*localhost:5001/api/values";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.False(result);
+
+            pattern = "**/LOCALHOST:5001/**";
+            result = FastPathMatcher.Match(pattern, path);
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

___
### New feature or improvement
- Extend the skyapm configuration, add `Component.HttpClient` section.
- Support stop header propagation on specific path by configing the `Component.HttpClient` section, dealing with some thirty part services not allow custom headers in the http request.

