### PR TITLE
ASP .NET /.NET Framework fixes

### DIFF
--- a/src/SkyApm.Agent.AspNet/AsyncContext.cs
+++ b/src/SkyApm.Agent.AspNet/AsyncContext.cs
@@ -1,0 +1,51 @@
+﻿/*
+* Licensed to the OpenSkywalking under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The OpenSkywalking licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Agent.AspNet
+{
+    internal static class AsyncContext
+    {
+        public static void Run(Func<Task> task)
+        {
+            using (new ContextScope())
+            {
+                Task.Run(async () => await task()).GetAwaiter().GetResult();
+            }
+        }
+
+        private class ContextScope : IDisposable
+        {
+            private readonly SynchronizationContext _current;
+
+            public ContextScope()
+            {
+                _current = SynchronizationContext.Current;
+                SynchronizationContext.SetSynchronizationContext(null);
+            }
+
+            public void Dispose()
+            {
+                SynchronizationContext.SetSynchronizationContext(_current);
+            }
+        }
+    }
+}

--- a/src/SkyApm.Agent.AspNet/AsyncContext.cs
+++ b/src/SkyApm.Agent.AspNet/AsyncContext.cs
@@ -1,20 +1,20 @@
 ﻿/*
-* Licensed to the OpenSkywalking under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for additional information regarding copyright ownership.
-* The OpenSkywalking licenses this file to You under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*/
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 using System;
 using System.Threading;

--- a/src/SkyApm.Agent.AspNet/Configuration/ConfigurationFactory.cs
+++ b/src/SkyApm.Agent.AspNet/Configuration/ConfigurationFactory.cs
@@ -1,4 +1,22 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using Microsoft.Extensions.Configuration;
 using SkyApm.Utilities.Configuration;
 using System;
 using System.Collections.Generic;

--- a/src/SkyApm.Agent.AspNet/Configuration/ConfigurationFactory.cs
+++ b/src/SkyApm.Agent.AspNet/Configuration/ConfigurationFactory.cs
@@ -16,13 +16,8 @@
  *
  */
 
-using Microsoft.Extensions.Configuration;
 using SkyApm.Utilities.Configuration;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SkyApm.Agent.AspNet.Configuration
 {

--- a/src/SkyApm.Agent.AspNet/Configuration/ConfigurationFactory.cs
+++ b/src/SkyApm.Agent.AspNet/Configuration/ConfigurationFactory.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Configuration;
+using SkyApm.Utilities.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SkyApm.Agent.AspNet.Configuration
+{
+    public class ConfigurationFactory : SkyApm.Utilities.Configuration.ConfigurationFactory
+    {
+        public ConfigurationFactory(IEnvironmentProvider environmentProvider, IEnumerable<IAdditionalConfigurationSource> additionalConfigurations) : base(environmentProvider, additionalConfigurations, null)
+        {
+        }
+    }
+}

--- a/src/SkyApm.Agent.AspNet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.AspNet/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ namespace SkyApm.Agent.AspNet.Extensions
             services.AddSingleton<IConfigAccessor, ConfigAccessor>();
             services.AddSingleton<IEnvironmentProvider, HostingEnvironmentProvider>();
             services.AddSingleton<InstrumentRequestCallback>();
-            services.AddSingleton<IConfigurationFactory, ConfigurationFactory>();
+            services.AddSingleton<IConfigurationFactory, SkyApm.Agent.AspNet.Configuration.ConfigurationFactory>();
 
             services.AddSingleton<ITracingContext, Tracing.TracingContext>();
             services.AddSingleton<ICarrierPropagator, CarrierPropagator>();

--- a/src/SkyApm.Agent.AspNet/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.AspNet/Extensions/ServiceCollectionExtensions.cs
@@ -51,9 +51,9 @@ namespace SkyApm.Agent.AspNet.Extensions
             services.AddSingleton<ICarrierPropagator, CarrierPropagator>();
             services.AddSingleton<ICarrierFormatter, Sw8CarrierFormatter>();
             services.AddSingleton<ISegmentContextFactory, SegmentContextFactory>();
-            services.AddSingleton<IEntrySegmentContextAccessor, EntrySegmentContextAccessor>();
-            services.AddSingleton<ILocalSegmentContextAccessor, LocalSegmentContextAccessor>();
-            services.AddSingleton<IExitSegmentContextAccessor, ExitSegmentContextAccessor>();
+            services.AddSingleton<IEntrySegmentContextAccessor, SkyApm.AspNet.Tracing.EntrySegmentContextAccessor>();
+            services.AddSingleton<ILocalSegmentContextAccessor, SkyApm.AspNet.Tracing.LocalSegmentContextAccessor>();
+            services.AddSingleton<IExitSegmentContextAccessor, SkyApm.AspNet.Tracing.ExitSegmentContextAccessor>();
             services.AddSingleton<ISamplerChainBuilder, SamplerChainBuilder>();
             services.AddSingleton<IUniqueIdGenerator, UniqueIdGenerator>();
             services.AddSingleton<ISegmentContextMapper, SegmentContextMapper>();

--- a/src/SkyApm.Agent.AspNet/InstrumentModule.cs
+++ b/src/SkyApm.Agent.AspNet/InstrumentModule.cs
@@ -19,7 +19,6 @@
 using CommonServiceLocator;
 using Microsoft.Extensions.DependencyInjection;
 using System.Web;
-using Nito.AsyncEx;
 using SkyApm.Agent.AspNet.Extensions;
 
 namespace SkyApm.Agent.AspNet

--- a/src/SkyApm.Agent.AspNet/SkyApm.Agent.AspNet.csproj
+++ b/src/SkyApm.Agent.AspNet/SkyApm.Agent.AspNet.csproj
@@ -28,6 +28,5 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="Microsoft.Web.Infrastructure" Version="1.0.0" />
-    <PackageReference Include="Nito.AsyncEx.Context" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/SkyApm.Agent.AspNet/Tracing/EntrySegmentContextAccessor.cs
+++ b/src/SkyApm.Agent.AspNet/Tracing/EntrySegmentContextAccessor.cs
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing;
+
+namespace SkyApm.AspNet.Tracing
+{
+    public class EntrySegmentContextAccessor : HttpContextContextAccessor<IEntrySegmentContextAccessor>, IEntrySegmentContextAccessor
+    {
+    }
+}

--- a/src/SkyApm.Agent.AspNet/Tracing/ExitSegmentContextAccessor.cs
+++ b/src/SkyApm.Agent.AspNet/Tracing/ExitSegmentContextAccessor.cs
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing;
+
+namespace SkyApm.AspNet.Tracing
+{
+    public class ExitSegmentContextAccessor : HttpContextContextAccessor<IExitSegmentContextAccessor>, IExitSegmentContextAccessor
+    {
+    }
+}

--- a/src/SkyApm.Agent.AspNet/Tracing/HttpContextContextAccessor.cs
+++ b/src/SkyApm.Agent.AspNet/Tracing/HttpContextContextAccessor.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing.Segments;
+using System.Web;
+
+namespace SkyApm.AspNet.Tracing
+{
+    /// <summary>
+    /// Sorry for the idiotic name. It's suppose to be "Accessor of the <see cref="SegmentContext"/> provided via <see cref="HttpContext"/>".
+    /// </summary>
+    public abstract class HttpContextContextAccessor<T> where T : class
+    {
+        public virtual SegmentContext Context
+        {
+            get => GetValueOrNull();
+            set => SetValue(value);
+        }
+
+        private SegmentContext GetValueOrNull()
+        {
+            if (HttpContext.Current != null && HttpContext.Current.Items.Contains(typeof(T)))
+            {
+                return HttpContext.Current.Items[typeof(T)] as SegmentContext;
+            }
+            return null;
+        }
+
+        private void SetValue(SegmentContext value)
+        {
+            if (HttpContext.Current != null)
+            {
+                HttpContext.Current.Items[typeof(T)] = value;
+            }
+        }
+    }
+}

--- a/src/SkyApm.Agent.AspNet/Tracing/LocalSegmentContextAccessor.cs
+++ b/src/SkyApm.Agent.AspNet/Tracing/LocalSegmentContextAccessor.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing;
+using SkyApm.Tracing.Segments;
+using System.Runtime.CompilerServices;
+
+namespace SkyApm.AspNet.Tracing
+{
+    public class LocalSegmentContextAccessor : HttpContextContextAccessor<ILocalSegmentContextAccessor>, ILocalSegmentContextAccessor
+    {
+        private readonly ConditionalWeakTable<SegmentContext, SegmentContext> _parent = new ConditionalWeakTable<SegmentContext, SegmentContext>();
+
+        public override SegmentContext Context
+        {
+            get => base.Context;
+            set
+            {
+                var current = base.Context;
+                if (value == null)
+                {
+                    if (_parent.TryGetValue(current, out var parent))
+                        base.Context = parent;
+                }
+                else
+                {
+                    _parent.Add(value, current);
+                    base.Context = value;
+                }
+            }
+        }
+    }
+}

--- a/src/SkyApm.Utilities.Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/SkyApm.Utilities.Configuration/ConfigurationBuilderExtensions.cs
@@ -34,22 +34,22 @@ namespace SkyApm.Utilities.Configuration
             var defaultLogFile = Path.Combine("logs", "skyapm-{Date}.log");
             var defaultConfig = new Dictionary<string, string>
             {
-                {"SkyWalking:Namespace", configuration.GetSection("SkyWalking:Namespace").Value ?? string.Empty },
-                {"SkyWalking:ServiceName", configuration.GetSection("SkyWalking:ServiceName").Value ?? "My_Service" },
-                {"Skywalking:ServiceInstanceName", configuration.GetSection("SkyWalking:ServiceInstanceName").Value ?? BuildDefaultServiceInstanceName() },
-                {"SkyWalking:HeaderVersions:0", configuration.GetSection("SkyWalking:HeaderVersions:0").Value ?? HeaderVersions.SW8 },
-                {"SkyWalking:Sampling:SamplePer3Secs", configuration.GetSection("SkyWalking:Sampling:SamplePer3Secs").Value ?? "-1" },
-                {"SkyWalking:Sampling:Percentage", configuration.GetSection("SkyWalking:Sampling:Percentage").Value ?? "-1" },
-                {"SkyWalking:Logging:Level",  configuration.GetSection("SkyWalking:Logging:Level").Value ?? "Information" },
-                {"SkyWalking:Logging:FilePath", configuration.GetSection("SkyWalking:Logging:FilePath").Value ?? defaultLogFile },
-                {"SkyWalking:Transport:Interval", configuration.GetSection("SkyWalking:Transport:Interval").Value ?? "3000" },
-                {"SkyWalking:Transport:ProtocolVersion", configuration.GetSection("SkyWalking:Transport:ProtocolVersion").Value ?? ProtocolVersions.V8 },
-                {"SkyWalking:Transport:QueueSize", configuration.GetSection("SkyWalking:Transport:QueueSize").Value ?? "30000" },
-                {"SkyWalking:Transport:BatchSize", configuration.GetSection("SkyWalking:Transport:BatchSize").Value ?? "3000" },
-                {"SkyWalking:Transport:gRPC:Servers",configuration.GetSection("SkyWalking:Transport:gRPC:Servers").Value ?? "localhost:11800" },
-                {"SkyWalking:Transport:gRPC:Timeout",configuration.GetSection("SkyWalking:Transport:gRPC:Timeout").Value ?? "10000" },
-                {"SkyWalking:Transport:gRPC:ReportTimeout",configuration.GetSection("SkyWalking:Transport:gRPC:ReportTimeout").Value ?? "600000" },
-                {"SkyWalking:Transport:gRPC:ConnectTimeout",configuration.GetSection("SkyWalking:Transport:gRPC:ConnectTimeout").Value ?? "10000" }
+                {"SkyWalking:Namespace", configuration?.GetSection("SkyWalking:Namespace").Value ?? string.Empty },
+                {"SkyWalking:ServiceName", configuration?.GetSection("SkyWalking:ServiceName").Value ?? "My_Service" },
+                {"Skywalking:ServiceInstanceName", configuration?.GetSection("SkyWalking:ServiceInstanceName").Value ?? BuildDefaultServiceInstanceName() },
+                {"SkyWalking:HeaderVersions:0", configuration?.GetSection("SkyWalking:HeaderVersions:0").Value ?? HeaderVersions.SW8 },
+                {"SkyWalking:Sampling:SamplePer3Secs", configuration?.GetSection("SkyWalking:Sampling:SamplePer3Secs").Value ?? "-1" },
+                {"SkyWalking:Sampling:Percentage", configuration?.GetSection("SkyWalking:Sampling:Percentage").Value ?? "-1" },
+                {"SkyWalking:Logging:Level",  configuration?.GetSection("SkyWalking:Logging:Level").Value ?? "Information" },
+                {"SkyWalking:Logging:FilePath", configuration?.GetSection("SkyWalking:Logging:FilePath").Value ?? defaultLogFile },
+                {"SkyWalking:Transport:Interval", configuration?.GetSection("SkyWalking:Transport:Interval").Value ?? "3000" },
+                {"SkyWalking:Transport:ProtocolVersion", configuration?.GetSection("SkyWalking:Transport:ProtocolVersion").Value ?? ProtocolVersions.V8 },
+                {"SkyWalking:Transport:QueueSize", configuration?.GetSection("SkyWalking:Transport:QueueSize").Value ?? "30000" },
+                {"SkyWalking:Transport:BatchSize", configuration?.GetSection("SkyWalking:Transport:BatchSize").Value ?? "3000" },
+                {"SkyWalking:Transport:gRPC:Servers",configuration?.GetSection("SkyWalking:Transport:gRPC:Servers").Value ?? "localhost:11800" },
+                {"SkyWalking:Transport:gRPC:Timeout",configuration?.GetSection("SkyWalking:Transport:gRPC:Timeout").Value ?? "10000" },
+                {"SkyWalking:Transport:gRPC:ReportTimeout",configuration?.GetSection("SkyWalking:Transport:gRPC:ReportTimeout").Value ?? "600000" },
+                {"SkyWalking:Transport:gRPC:ConnectTimeout",configuration?.GetSection("SkyWalking:Transport:gRPC:ConnectTimeout").Value ?? "10000" }
             };
             return builder.AddInMemoryCollection(defaultConfig);
         }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#300 
#309
___
### Bug fix
- Bug description.
Exception on application initialization.
- How to fix?
Default implementation of `ConfigurationFactory` for ASP .NET Core depends on `IConfiguration` object to be provided via DI. ASP .NET agent doesn't have access to this object, which leads to exception on initialization.
This bug was fixed by providing a separate implementation of `ConfigurationFactory`, which doesn't require `IConfiguration` object. I've also modified `AddSkyWalkingDefaultConfig` method to use default values if the provided configuration object is null

___
### Bug fix
- Bug description.
Exception thrown when application is build using ready-to-publish nuget packages. 
- How to fix?
Removed dependencies to `Nito.AsyncEx.Context` package. Reverted some of the code changes - ASP .NET agent is now using it's own implementation of `AsyncContext`.

___
### Bug fix
- Bug description.
Traces are not recorded for WebAPI calls.
- How to fix?
ASP .NET doesn't guarantee to run `ApplicationOnEndRequest` on the same thread or in the same ExecutionContext as the rest of the Web Request.
To mitigate this bug, `ContextAccessors` have been rewritten to use current `HttpContext` as `SegmentContext` provider.

___
### Bug fix
- Bug description.
`HttpTracingHandler` doesn't work with synchronous endpoints
- Code example.
```
        [HttpGet]
        [Route("getwh2")]
        public IHttpActionResult GetWH2()
        {
            var httpClient = new HttpClient(new HttpTracingHandler());
            var values = httpClient.GetStringAsync("http://localhost:5001/api/values").Result;
            return Json(values);
        }
```
Webrequest to this endpoint will never end and there will be a runaway thread on host.
- How to fix?
Rewritten `SendAsync` on `HttpTracingHandler` from `async` to `Task`.
This is a bit of a mind-bender. The main issue here is that the default definition of `SendAsync` method in `DelegatingHandler` is NOT an `async` method. `HttpTracingHandler` inherits from `DelegatingHandler` but it changes the definition of overloaded method `SendAsync`, and marks it as an `async`. I haven't found exactly, why this method works property in async context, but locks/freezes when run from synchronous call, but rewriting it to `Task` makes it work in both cases.

___
I would be grateful for any feedback or additional input. Especially last bugfix should be put under scrutiny.
