### PR TITLE
fix(SkyApm.Diagnostics.SqlClient): added support for Microsoft.Data.SqlClient in .NET Core

### DIFF
--- a/src/SkyApm.Diagnostics.SqlClient/SqlClientDiagnosticStrings.cs
+++ b/src/SkyApm.Diagnostics.SqlClient/SqlClientDiagnosticStrings.cs
@@ -27,5 +27,9 @@ namespace SkyApm.Diagnostics.SqlClient
         public const string SqlBeforeExecuteCommand = "System.Data.SqlClient.WriteCommandBefore";
         public const string SqlAfterExecuteCommand = "System.Data.SqlClient.WriteCommandAfter";
         public const string SqlErrorExecuteCommand = "System.Data.SqlClient.WriteCommandError";
+
+        public const string DotNetCoreSqlBeforeExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandBefore";
+        public const string DotNetCoreSqlAfterExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandAfter";
+        public const string DotNetCoreSqlErrorExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandError";
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [] New feature provided
- [ ] Improve performance

- Related issues
  #378 
___
### Bug fix
- The diagnostic name of SqlClient has been changed in Microsoft.Data.SqlClient for .NET Core. SqlClientDiagnosticProcessor does not work for them.

- Added new diagnostic listener for Microsoft.Data.SqlClient

___
### New feature or improvement
- Describe the details and related test reports.
