### PR TITLE
fix(SkyApm.Diagnostics.SqlClient): added support for Microsoft.Data.SqlClient in .NET Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,5 @@ generated/
 generated-v3/
 
 /sample/java-integration-demo/agent
+
+.DS_Store

--- a/src/SkyApm.Diagnostics.SqlClient/SkyApm.Diagnostics.SqlClient.csproj
+++ b/src/SkyApm.Diagnostics.SqlClient/SkyApm.Diagnostics.SqlClient.csproj
@@ -16,7 +16,4 @@
     <ProjectReference Include="..\SkyApm.Core\SkyApm.Core.csproj" />
     <ProjectReference Include="..\SkyApm.Utilities.DependencyInjection\SkyApm.Utilities.DependencyInjection.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.0" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/src/SkyApm.Diagnostics.SqlClient/SqlClientDiagnosticProcessor.cs
+++ b/src/SkyApm.Diagnostics.SqlClient/SqlClientDiagnosticProcessor.cs
@@ -20,6 +20,7 @@ using System;
 using System.Data.Common;
 using System.Linq;
 using SkyApm.Tracing;
+using SkyApm.Config;
 
 namespace SkyApm.Diagnostics.SqlClient
 {
@@ -27,13 +28,16 @@ namespace SkyApm.Diagnostics.SqlClient
     {
         private readonly ITracingContext _tracingContext;
         private readonly IExitSegmentContextAccessor _contextAccessor;
+        private readonly TracingConfig _tracingConfig;
 
         public SqlClientTracingDiagnosticProcessor(ITracingContext tracingContext,
-                IExitSegmentContextAccessor contextAccessor)
+            IExitSegmentContextAccessor contextAccessor, IConfigAccessor configAccessor)
         {
             _tracingContext = tracingContext;
             _contextAccessor = contextAccessor;
+            _tracingConfig = configAccessor.Get<TracingConfig>();
         }
+
 
         public string ListenerName { get; } = SqlClientDiagnosticStrings.DiagnosticListenerName;
 
@@ -73,7 +77,7 @@ namespace SkyApm.Diagnostics.SqlClient
             var context = _contextAccessor.Context;
             if (context != null)
             {
-                context.Span.ErrorOccurred(ex);
+                context.Span.ErrorOccurred(ex, _tracingConfig);
                 _tracingContext.Release(context);
             }
         }

--- a/src/SkyApm.Diagnostics.SqlClient/SqlClientDiagnosticStrings.cs
+++ b/src/SkyApm.Diagnostics.SqlClient/SqlClientDiagnosticStrings.cs
@@ -24,8 +24,16 @@ namespace SkyApm.Diagnostics.SqlClient
 
         public const string SqlClientPrefix = "sqlClient ";
 
+        #region System.Data.SqlClient
         public const string SqlBeforeExecuteCommand = "System.Data.SqlClient.WriteCommandBefore";
         public const string SqlAfterExecuteCommand = "System.Data.SqlClient.WriteCommandAfter";
         public const string SqlErrorExecuteCommand = "System.Data.SqlClient.WriteCommandError";
+        #endregion
+
+        #region Microsoft.Data.SqlClient
+        public const string DotNetCoreSqlBeforeExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandBefore";
+        public const string DotNetCoreSqlAfterExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandAfter";
+        public const string DotNetCoreSqlErrorExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandError";
+        #endregion
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
 #378 
___
### Bug fix
- The diagnostic name of SqlClient has been changed in Microsoft.Data.SqlClient for .NET Core. SqlClientDiagnosticProcessor does not work for them.

- Added new diagnostic listener for Microsoft.Data.SqlClient

___
### New feature or improvement
- Describe the details and related test reports.
