### PR TITLE
feature: Support collect request header and body for HttpClient

### DIFF
--- a/sample/SkyApm.Sample.Backend/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.Backend/Controllers/ValuesController.cs
@@ -35,5 +35,11 @@ namespace SkyApm.Sample.Backend.Controllers
         {
             return "stop propagation";
         }
+
+        [HttpPost("postin")]
+        public string PostIn([FromBody]PostModel model)
+        {
+            return model.Name;
+        }
     } 
 }

--- a/sample/SkyApm.Sample.Backend/Models/PostModel.cs
+++ b/sample/SkyApm.Sample.Backend/Models/PostModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SkyApm.Sample.Backend.Models
+{
+    public class PostModel
+    {
+        public string Name { get; set; }
+    }
+}

--- a/sample/SkyApm.Sample.Frontend/Controllers/ValuesController.cs
+++ b/sample/SkyApm.Sample.Frontend/Controllers/ValuesController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -32,6 +33,13 @@ namespace SkyApm.Sample.Frontend.Controllers
         {
             await new HttpClient().GetAsync("http://localhost:5002/api/values");
             return new string[] { "value1", "value2" };
+        }
+
+        [HttpGet("postin")]
+        public async Task<string> PostIn()
+        {
+            var result = await new HttpClient().PostAsync("http://localhost:5002/api/values/postin", JsonContent.Create(new { Name = "SkyApm" }));
+            return await result.Content.ReadAsStringAsync();
         }
 
         [HttpGet("{id}")]

--- a/sample/SkyApm.Sample.Frontend/SkyApm.Sample.Frontend.csproj
+++ b/sample/SkyApm.Sample.Frontend/SkyApm.Sample.Frontend.csproj
@@ -13,6 +13,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" PrivateAssets="All" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Update="appsettings.json">

--- a/sample/SkyApm.Sample.Frontend/skyapm.json
+++ b/sample/SkyApm.Sample.Frontend/skyapm.json
@@ -37,7 +37,11 @@
         "CollectBodyLengthThreshold": 4096
       },
       "HttpClient": {
-        "StopHeaderPropagationPaths": [ "**/localhost:5002/api/values/stoppropagation" ]
+        "StopHeaderPropagationPaths": [ "**/localhost:5002/api/values/stoppropagation" ],
+        "CollectRequestHeaders": [ "User-Agent","sw8" ],
+        "CollectRequestBodyContentTypes": [ "application/json", "application/x-www-form-urlencoded" ],
+        "CollectResponseBodyContentTypes": [ "application/json", "application/x-www-form-urlencoded", "text/plain" ],
+        "CollectBodyLengthThreshold": 4096
       }
     }
   }

--- a/src/SkyApm.Abstractions/Common/Tags.cs
+++ b/src/SkyApm.Abstractions/Common/Tags.cs
@@ -31,7 +31,9 @@ namespace SkyApm.Common
 
         public static readonly string HTTP_HEADERS = "http.headers";
 
-        public static readonly string HTTP_BODY = "http.body";
+        public static readonly string HTTP_REQUEST_BODY = "http.request_body";
+
+        public static readonly string HTTP_RESPONSE_BODY = "http.response_body";
 
         public static readonly string STATUS_CODE = "status_code";
 

--- a/src/SkyApm.Diagnostics.AspNetCore/Handlers/DefaultHostingDiagnosticHandler.cs
+++ b/src/SkyApm.Diagnostics.AspNetCore/Handlers/DefaultHostingDiagnosticHandler.cs
@@ -80,7 +80,7 @@ namespace SkyApm.Diagnostics.AspNetCore.Handlers
             {
                 var body = CollectBody(httpContext, _config.CollectBodyLengthThreshold);
                 if (!string.IsNullOrEmpty(body))
-                    context.Span.AddTag(Tags.HTTP_BODY, body);
+                    context.Span.AddTag(Tags.HTTP_REQUEST_BODY, body);
             }
         }
 
@@ -155,7 +155,7 @@ namespace SkyApm.Diagnostics.AspNetCore.Handlers
             try
             {
                 var encoding = contentType.CharSet.ToEncoding(Encoding.UTF8);
-                using (var reader = new StreamReader(request.Body, encoding, true, lengthThreshold, true))
+                using (var reader = new StreamReader(request.Body, encoding, true, 1024, true))
                 {
                     var body = reader.ReadToEndAsync().Result;
                     return body;

--- a/src/SkyApm.Diagnostics.HttpClient/Config/HttpClientDiagnosticConfig.cs
+++ b/src/SkyApm.Diagnostics.HttpClient/Config/HttpClientDiagnosticConfig.cs
@@ -13,5 +13,26 @@ namespace SkyApm.Diagnostics.HttpClient.Config
         /// Usage: a/b/c => a/b/c, a/* => a/b, a/** => a/b/c/d, a/?/c => a/b/c
         /// </summary>
         public List<string> StopHeaderPropagationPaths { get; set; }
+
+        /// <summary>
+        /// Collect specific request headers as span tag
+        /// </summary>
+        public List<string> CollectRequestHeaders { get; set; }
+
+        /// <summary>
+        /// Collect request body as span tag for specific Content-Type
+        /// </summary>
+        public List<string> CollectRequestBodyContentTypes { get; set; }
+
+        /// <summary>
+        /// Collect response body as span tag for specific Content-Type
+        /// </summary>
+        public List<string> CollectResponseBodyContentTypes { get; set; }
+
+        /// <summary>
+        /// Request/Response body will skip collecting if the content length is larger than this value.
+        /// </summary>
+        public int CollectBodyLengthThreshold { get; set; }
+
     }
 }

--- a/src/SkyApm.Diagnostics.HttpClient/Extensions/HttpContentExtensions.cs
+++ b/src/SkyApm.Diagnostics.HttpClient/Extensions/HttpContentExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace SkyApm.Diagnostics.HttpClient.Extensions
+{
+    internal static class HttpContentExtensions
+    {
+        public static string TryCollectAsString(this HttpContent httpContent, IEnumerable<string> contentTypeFilter, int lengthThreshold)
+        {
+            if (httpContent == null || httpContent.Headers.ContentLength > lengthThreshold)
+                return null;
+
+            var mediaHeader = httpContent.Headers.ContentType;
+            if (mediaHeader == null || !contentTypeFilter.Any(supportedType => mediaHeader.MediaType == supportedType))
+            {
+                return null;
+            }
+
+            try
+            {
+                var responseBody = httpContent.ReadAsStringAsync().Result;
+                // after ReadAsString(), the content length will be filled, in case of the Content-Length did not present in http header,
+                // so we recheck the skip threhold
+                if (httpContent.Headers.ContentLength > lengthThreshold)
+                    return null;
+                return responseBody;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

___
### New feature or improvement
- Support collect request header and body for HttpClient.

- Scenarios: When communicating with thrid party, we may want to logging the request/response info for logging or diagnostic purpose, also helpful for debugging in development environment.

Usage: Config at `Skywalking:Component:HttpClient` section.
![image](https://user-images.githubusercontent.com/11673037/112482359-f17b0b00-8db2-11eb-8278-d683eac8016a.png)


captured span looks like bellow:
![image](https://user-images.githubusercontent.com/11673037/112481729-4702e800-8db2-11eb-8809-9218ce98cd53.png)



