### PR TITLE
optimize: Scale the cpu usage value to percentage format.

### DIFF
--- a/src/SkyApm.Core/Common/CpuHelpers.cs
+++ b/src/SkyApm.Core/Common/CpuHelpers.cs
@@ -40,7 +40,7 @@ namespace SkyApm.Common
                 {
                     var prevCpuTime = _prevCpuTime;
                     var currentCpuTime = process.TotalProcessorTime;
-                    var usagePercent = (currentCpuTime.TotalMilliseconds - prevCpuTime) / interval;
+                    var usagePercent = (currentCpuTime.TotalMilliseconds - prevCpuTime) * 100 / interval;
                     Interlocked.Exchange(ref _prevCpuTime, currentCpuTime.TotalMilliseconds);
                     Interlocked.Exchange(ref _usagePercent, usagePercent);
                     await Task.Delay(interval);


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
Links #286 
Closes #408 
___
### Bug fix
- cpu usage value always shows zero on Skywalking UI dashboard.

- How to fix?
multiply the cpu-usage-value by 100 before send to oap-server

fixed chart looks like bellow:
![image](https://user-images.githubusercontent.com/11673037/114669118-20dac300-9d34-11eb-9e17-8555f9ca6c89.png)


