### PR TITLE
feature: Support ignore paths for HttpClient

### DIFF
--- a/src/SkyApm.Diagnostics.HttpClient/Config/HttpClientDiagnosticConfig.cs
+++ b/src/SkyApm.Diagnostics.HttpClient/Config/HttpClientDiagnosticConfig.cs
@@ -9,6 +9,12 @@ namespace SkyApm.Diagnostics.HttpClient.Config
     public class HttpClientDiagnosticConfig
     {
         /// <summary>
+        /// Paths to ignore, support wildchar match.
+        /// Usage: a/b/c => a/b/c, a/* => a/b, a/** => a/b/c/d, a/?/c => a/b/c
+        /// </summary>
+        public List<string> IgnorePaths { get; set; }
+
+        /// <summary>
         /// Stop header propagation on specific paths, path support wildchar match.
         /// Usage: a/b/c => a/b/c, a/* => a/b, a/** => a/b/c/d, a/?/c => a/b/c
         /// </summary>

--- a/src/SkyApm.Diagnostics.HttpClient/Handlers/DefaultRequestDiagnosticHandler.cs
+++ b/src/SkyApm.Diagnostics.HttpClient/Handlers/DefaultRequestDiagnosticHandler.cs
@@ -48,7 +48,16 @@ namespace SkyApm.Diagnostics.HttpClient.Handlers
         public void Handle(ITracingContext tracingContext, HttpRequestMessage request)
         {
             var operationName = request.RequestUri.GetLeftPart(UriPartial.Path);
-            var shouldStopPropagation = _httpClientDiagnosticConfig.StopHeaderPropagationPaths != null 
+
+            var ignored = _httpClientDiagnosticConfig.IgnorePaths != null
+                && _httpClientDiagnosticConfig.IgnorePaths
+                    .Any(pattern => FastPathMatcher.Match(pattern, operationName));
+            if (ignored)
+            {
+                return;
+            }
+
+            var shouldStopPropagation = _httpClientDiagnosticConfig.StopHeaderPropagationPaths != null
                 && _httpClientDiagnosticConfig.StopHeaderPropagationPaths
                     .Any(pattern => FastPathMatcher.Match(pattern, operationName));
 


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

___
### New feature or improvement
- Support ignore paths for HttpClient.

In some scenarios, we may not care about some call links, but this part of the data is quite large, so large that it will affect our normal business. 
For example, the heartbeat of some middleware.
At this time, we can selectively ignore some call chains.
