### PR TITLE
Allows to modify the start time and end time properties of the SegmentSpan object.

### DIFF
--- a/src/SkyApm.Abstractions/Tracing/ISegmentContextFactory.cs
+++ b/src/SkyApm.Abstractions/Tracing/ISegmentContextFactory.cs
@@ -23,12 +23,12 @@ namespace SkyApm.Tracing
 {
     public interface ISegmentContextFactory
     {
-        SegmentContext CreateEntrySegment(string operationName, ICarrier carrier);
+        SegmentContext CreateEntrySegment(string operationName, ICarrier carrier, long startTimeMilliseconds = default);
 
-        SegmentContext CreateLocalSegment(string operationName);
+        SegmentContext CreateLocalSegment(string operationName, long startTimeMilliseconds = default);
 
-        SegmentContext CreateExitSegment(string operationName, StringOrIntValue networkAddress);
-        
-        void Release(SegmentContext segmentContext);
+        SegmentContext CreateExitSegment(string operationName, StringOrIntValue networkAddress, long startTimeMilliseconds = default);
+
+        void Release(SegmentContext segmentContext, long endTimeMilliseconds = default);
     }
 }

--- a/src/SkyApm.Abstractions/Tracing/ITracingContext.cs
+++ b/src/SkyApm.Abstractions/Tracing/ITracingContext.cs
@@ -22,13 +22,13 @@ namespace SkyApm.Tracing
 {
     public interface ITracingContext
     {
-        SegmentContext CreateEntrySegmentContext(string operationName, ICarrierHeaderCollection carrierHeader);
+        SegmentContext CreateEntrySegmentContext(string operationName, ICarrierHeaderCollection carrierHeader, long startTimeMilliseconds = default);
 
-        SegmentContext CreateLocalSegmentContext(string operationName);
+        SegmentContext CreateLocalSegmentContext(string operationName, long startTimeMilliseconds = default);
 
         SegmentContext CreateExitSegmentContext(string operationName, string networkAddress,
-            ICarrierHeaderCollection carrierHeader = default(ICarrierHeaderCollection));
+            ICarrierHeaderCollection carrierHeader = default, long startTimeMilliseconds = default);
 
-        void Release(SegmentContext segmentContext);
+        void Release(SegmentContext segmentContext, long endTimeMilliseconds = default);
     }
 }

--- a/src/SkyApm.Abstractions/Tracing/Segments/SegmentContext.cs
+++ b/src/SkyApm.Abstractions/Tracing/Segments/SegmentContext.cs
@@ -39,14 +39,14 @@ namespace SkyApm.Tracing.Segments
         public SegmentReferenceCollection References { get; } = new SegmentReferenceCollection();
 
         public SegmentContext(string traceId, string segmentId, bool sampled, string serviceId, string serviceInstanceId,
-            string operationName, SpanType spanType)
+            string operationName, SpanType spanType, long startTimeMilliseconds = default)
         {
             TraceId = traceId;
             Sampled = sampled;
             SegmentId = segmentId;
             ServiceId = serviceId;
             ServiceInstanceId = serviceInstanceId;
-            Span = new SegmentSpan(operationName, spanType);
+            Span = new SegmentSpan(operationName, spanType, startTimeMilliseconds);
         }
     }
 }

--- a/src/SkyApm.Abstractions/Tracing/Segments/SegmentSpan.cs
+++ b/src/SkyApm.Abstractions/Tracing/Segments/SegmentSpan.cs
@@ -30,7 +30,7 @@ namespace SkyApm.Tracing.Segments
 
         public int ParentSpanId { get; } = -1;
 
-        public long StartTime { get; } = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        public long StartTime { get; }
 
         public long EndTime { get; private set; }
 
@@ -49,10 +49,11 @@ namespace SkyApm.Tracing.Segments
 
         public LogCollection Logs { get; } = new LogCollection();
 
-        public SegmentSpan(string operationName, SpanType spanType)
+        public SegmentSpan(string operationName, SpanType spanType, long startTimeMilliseconds = default)
         {
             OperationName = new StringOrIntValue(operationName);
             SpanType = spanType;
+            StartTime = startTimeMilliseconds == default ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() : startTimeMilliseconds;
         }
 
         public SegmentSpan AddTag(string key, string value)
@@ -79,9 +80,9 @@ namespace SkyApm.Tracing.Segments
             Logs.AddLog(log);
         }
 
-        public void Finish()
+        public void Finish(long endTimeMilliseconds = default)
         {
-            EndTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            EndTime = endTimeMilliseconds == default ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() : endTimeMilliseconds;
         }
     }
 

--- a/src/SkyApm.Core/Tracing/SegmentContextFactory.cs
+++ b/src/SkyApm.Core/Tracing/SegmentContextFactory.cs
@@ -51,7 +51,7 @@ namespace SkyApm.Tracing
             _instrumentConfig = configAccessor.Get<InstrumentConfig>();
         }
 
-        public SegmentContext CreateEntrySegment(string operationName, ICarrier carrier)
+        public SegmentContext CreateEntrySegment(string operationName, ICarrier carrier, long startTimeMilliseconds = default)
         {
             var traceId = GetTraceId(carrier);
             var segmentId = GetSegmentId();
@@ -59,7 +59,7 @@ namespace SkyApm.Tracing
             var segmentContext = new SegmentContext(traceId, segmentId, sampled,
                 _instrumentConfig.ServiceName ?? _instrumentConfig.ApplicationCode,
                 _instrumentConfig.ServiceInstanceName,
-                operationName, SpanType.Entry);
+                operationName, SpanType.Entry, startTimeMilliseconds);
 
             if (carrier.HasValue)
             {
@@ -83,7 +83,7 @@ namespace SkyApm.Tracing
             return segmentContext;
         }
 
-        public SegmentContext CreateLocalSegment(string operationName)
+        public SegmentContext CreateLocalSegment(string operationName, long startTimeMilliseconds = default)
         {
             var parentSegmentContext = GetParentSegmentContext(SpanType.Local);
             var traceId = GetTraceId(parentSegmentContext);
@@ -92,7 +92,7 @@ namespace SkyApm.Tracing
             var segmentContext = new SegmentContext(traceId, segmentId, sampled,
                 _instrumentConfig.ServiceName ?? _instrumentConfig.ApplicationCode,
                 _instrumentConfig.ServiceInstanceName,
-                operationName, SpanType.Local);
+                operationName, SpanType.Local, startTimeMilliseconds);
 
             if (parentSegmentContext != null)
             {
@@ -118,7 +118,7 @@ namespace SkyApm.Tracing
             return segmentContext;
         }
 
-        public SegmentContext CreateExitSegment(string operationName, StringOrIntValue networkAddress)
+        public SegmentContext CreateExitSegment(string operationName, StringOrIntValue networkAddress, long startTimeMilliseconds = default)
         {
             var parentSegmentContext = GetParentSegmentContext(SpanType.Exit);
             var traceId = GetTraceId(parentSegmentContext);
@@ -127,7 +127,7 @@ namespace SkyApm.Tracing
             var segmentContext = new SegmentContext(traceId, segmentId, sampled,
                 _instrumentConfig.ServiceName ?? _instrumentConfig.ApplicationCode,
                 _instrumentConfig.ServiceInstanceName,
-                operationName, SpanType.Exit);
+                operationName, SpanType.Exit, startTimeMilliseconds);
 
             if (parentSegmentContext != null)
             {
@@ -154,13 +154,13 @@ namespace SkyApm.Tracing
             return segmentContext;
         }
 
-        public void Release(SegmentContext segmentContext)
+        public void Release(SegmentContext segmentContext, long endTimeMilliseconds = default)
         {
-            segmentContext.Span.Finish();
+            segmentContext.Span.Finish(endTimeMilliseconds);
             switch (segmentContext.Span.SpanType)
             {
                 case SpanType.Entry:
-                     _entrySegmentContextAccessor.Context = null;
+                    _entrySegmentContextAccessor.Context = null;
                     break;
                 case SpanType.Local:
                     _localSegmentContextAccessor.Context = null;

--- a/src/SkyApm.Core/Tracing/TracingContext.cs
+++ b/src/SkyApm.Core/Tracing/TracingContext.cs
@@ -37,37 +37,37 @@ namespace SkyApm.Tracing
             _segmentDispatcher = segmentDispatcher;
         }
 
-        public SegmentContext CreateEntrySegmentContext(string operationName, ICarrierHeaderCollection carrierHeader)
+        public SegmentContext CreateEntrySegmentContext(string operationName, ICarrierHeaderCollection carrierHeader, long startTimeMilliseconds = default)
         {
             if (operationName == null) throw new ArgumentNullException(nameof(operationName));
             var carrier = _carrierPropagator.Extract(carrierHeader);
-            return _segmentContextFactory.CreateEntrySegment(operationName, carrier);
+            return _segmentContextFactory.CreateEntrySegment(operationName, carrier, startTimeMilliseconds);
         }
 
-        public SegmentContext CreateLocalSegmentContext(string operationName)
+        public SegmentContext CreateLocalSegmentContext(string operationName, long startTimeMilliseconds = default)
         {
             if (operationName == null) throw new ArgumentNullException(nameof(operationName));
-            return _segmentContextFactory.CreateLocalSegment(operationName);
+            return _segmentContextFactory.CreateLocalSegment(operationName, startTimeMilliseconds);
         }
 
         public SegmentContext CreateExitSegmentContext(string operationName, string networkAddress,
-            ICarrierHeaderCollection carrierHeader = default(ICarrierHeaderCollection))
+            ICarrierHeaderCollection carrierHeader = default, long startTimeMilliseconds = default)
         {
             var segmentContext =
-                _segmentContextFactory.CreateExitSegment(operationName, new StringOrIntValue(networkAddress));
+                _segmentContextFactory.CreateExitSegment(operationName, new StringOrIntValue(networkAddress), startTimeMilliseconds);
             if (carrierHeader != null)
                 _carrierPropagator.Inject(segmentContext, carrierHeader);
             return segmentContext;
         }
 
-        public void Release(SegmentContext segmentContext)
+        public void Release(SegmentContext segmentContext, long endTimeMilliseconds = default)
         {
             if (segmentContext == null)
             {
                 return;
             }
-            
-            _segmentContextFactory.Release(segmentContext);
+
+            _segmentContextFactory.Release(segmentContext, endTimeMilliseconds);
             if (segmentContext.Sampled)
                 _segmentDispatcher.Dispatch(segmentContext);
         }


### PR DESCRIPTION
Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

___
### New feature
- Allows to modify the start time and end time properties of the SegmentSpan object.

  In a specific scenario, I want to modify the start time and end time properties of the SegmentSpan object.
  For example, in the diagnostic information of `StackExchange.Redis`(SERedis), the start time and end time are determined by SERedis
