### PR TITLE
fix: AsyncQueueSkyApmLogDispatcher._offset is not correct exactly in muti threads

### DIFF
--- a/src/SkyApm.Core/Transport/AsyncQueueSkyApmLogDispatcher.cs
+++ b/src/SkyApm.Core/Transport/AsyncQueueSkyApmLogDispatcher.cs
@@ -84,8 +84,6 @@ namespace SkyApm.Transport
                 _loggerReporter.ReportAsync(loggers, token);
             }
 
-            Interlocked.Exchange(ref _offset, _segmentQueue.Count);
-
             return Task.CompletedTask;
         }
         public void Close()


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [ ] New feature provided
- [ ] Improve performance

- Related issues
#514 
___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
