### PR TITLE
移除SkyApm.Agent.Hosting中非必要依赖.减少包大小.以及docker镜像打包后的大小.

### DIFF
--- a/sample/SkyApm.Sample.Backend/SkyApm.Sample.Backend.csproj
+++ b/sample/SkyApm.Sample.Backend/SkyApm.Sample.Backend.csproj
@@ -4,7 +4,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.26.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.51.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\SkyApm.Agent.AspNetCore\SkyApm.Agent.AspNetCore.csproj" />
@@ -18,10 +18,10 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.17" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.12" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.13" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<Content Update="appsettings.json">

--- a/sample/SkyApm.Sample.FreeSql/SkyApm.Sample.FreeSqlSqlite.csproj
+++ b/sample/SkyApm.Sample.FreeSql/SkyApm.Sample.FreeSqlSqlite.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
-    <PackageReference Include="FreeSql" Version="3.2.685" />
-    <PackageReference Include="FreeSql.Provider.Sqlite" Version="3.2.685" />
+    <PackageReference Include="FreeSql" Version="3.2.687" />
+    <PackageReference Include="FreeSql.Provider.Sqlite" Version="3.2.687" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SkyApm.Agent.AspNetCore\SkyApm.Agent.AspNetCore.csproj" />

--- a/sample/SkyApm.Sample.Frontend/SkyApm.Sample.Frontend.csproj
+++ b/sample/SkyApm.Sample.Frontend/SkyApm.Sample.Frontend.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/SkyApm.Sample.Logging/SkyApm.Sample.Logging.csproj
+++ b/sample/SkyApm.Sample.Logging/SkyApm.Sample.Logging.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\SkyApm.Agent.AspNetCore\SkyApm.Agent.AspNetCore.csproj" />

--- a/sample/grpc/SkyApm.Sample.GrpcProto/SkyApm.Sample.GrpcProto.csproj
+++ b/sample/grpc/SkyApm.Sample.GrpcProto/SkyApm.Sample.GrpcProto.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.21.5" />
-    <PackageReference Include="Grpc" Version="2.37.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.48.0">
+    <PackageReference Include="Google.Protobuf" Version="3.21.12" />
+    <PackageReference Include="Grpc" Version="2.46.6" />
+    <PackageReference Include="Grpc.Tools" Version="2.51.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -17,13 +17,14 @@
  */
 
 using Microsoft.Extensions.Hosting;
+using SkyApm;
+using SkyApm.Agent.Hosting;
 using SkyApm.Config;
 using SkyApm.Diagnostics;
-using SkyApm.Diagnostics.EntityFrameworkCore;
 using SkyApm.Diagnostics.Grpc;
 using SkyApm.Diagnostics.Grpc.Net.Client;
 using SkyApm.Diagnostics.HttpClient;
-using SkyApm.Diagnostics.SqlClient;
+using SkyApm.Diagnostics.MSLogging;
 using SkyApm.Sampling;
 using SkyApm.Service;
 using SkyApm.Tracing;
@@ -33,10 +34,8 @@ using SkyApm.Utilities.Configuration;
 using SkyApm.Utilities.DependencyInjection;
 using SkyApm.Utilities.Logging;
 using System;
-using SkyApm;
-using SkyApm.Agent.Hosting;
-using SkyApm.Diagnostics.MSLogging;
 using ILoggerFactory = SkyApm.Logging.ILoggerFactory;
+// ReSharper disable UnusedMethodReturnValue.Global
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -62,7 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IExecutionService, SegmentReportService>();
             services.AddSingleton<IExecutionService, CLRStatsService>();
             services.AddSingleton<IInstrumentStartup, InstrumentStartup>();
-            services.AddSingleton<IRuntimeEnvironment>(RuntimeEnvironment.Instance);
+            services.AddSingleton(RuntimeEnvironment.Instance);
             services.AddSingleton<TracingDiagnosticProcessorObserver>();
             services.AddSingleton<IConfigAccessor, ConfigAccessor>();
             services.AddSingleton<IConfigurationFactory, ConfigurationFactory>();
@@ -73,9 +72,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var extensions = services.AddSkyApmExtensions()
                 .AddHttpClient()
                 .AddGrpcClient()
-                .AddSqlClient()
                 .AddGrpc()
-                .AddEntityFrameworkCore(c => c.AddPomeloMysql().AddNpgsql().AddSqlite())
                 .AddMSLogging();
 
             extensionsSetup?.Invoke(extensions);

--- a/src/SkyApm.Agent.Hosting/InstrumentationHostedService.cs
+++ b/src/SkyApm.Agent.Hosting/InstrumentationHostedService.cs
@@ -16,9 +16,9 @@
  *
  */
 
+using Microsoft.Extensions.Hosting;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
 
 namespace SkyApm.Agent.Hosting
 {

--- a/src/SkyApm.Agent.Hosting/SkyApm.Agent.Hosting.csproj
+++ b/src/SkyApm.Agent.Hosting/SkyApm.Agent.Hosting.csproj
@@ -25,16 +25,11 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />
-        <ProjectReference Include="..\SkyApm.Diagnostics.EntityFrameworkCore.Npgsql\SkyApm.Diagnostics.EntityFrameworkCore.Npgsql.csproj" />
-        <ProjectReference Include="..\SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql\SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql.csproj" />
-        <ProjectReference Include="..\SkyApm.Diagnostics.EntityFrameworkCore.Sqlite\SkyApm.Diagnostics.EntityFrameworkCore.Sqlite.csproj" />
-        <ProjectReference Include="..\SkyApm.Diagnostics.EntityFrameworkCore\SkyApm.Diagnostics.EntityFrameworkCore.csproj" />
         <ProjectReference Include="..\SkyApm.Core\SkyApm.Core.csproj" />
         <ProjectReference Include="..\SkyApm.Diagnostics.Grpc.Net.Client\SkyApm.Diagnostics.Grpc.Net.Client.csproj" />
         <ProjectReference Include="..\SkyApm.Diagnostics.Grpc\SkyApm.Diagnostics.Grpc.csproj" />
         <ProjectReference Include="..\SkyApm.Diagnostics.HttpClient\SkyApm.Diagnostics.HttpClient.csproj" />
         <ProjectReference Include="..\SkyApm.Diagnostics.MSLogging\SkyApm.Diagnostics.MSLogging.csproj" />
-        <ProjectReference Include="..\SkyApm.Diagnostics.SqlClient\SkyApm.Diagnostics.SqlClient.csproj" />
         <ProjectReference Include="..\SkyApm.Transport.Grpc\SkyApm.Transport.Grpc.csproj" />
         <ProjectReference Include="..\SkyApm.Utilities.Configuration\SkyApm.Utilities.Configuration.csproj" />
         <ProjectReference Include="..\SkyApm.Utilities.DependencyInjection\SkyApm.Utilities.DependencyInjection.csproj" />

--- a/src/SkyApm.Diagnostics.CAP/SkyApm.Diagnostics.CAP.csproj
+++ b/src/SkyApm.Diagnostics.CAP/SkyApm.Diagnostics.CAP.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="DotNetCore.CAP" Version="6.2.1" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-		<PackageReference Include="DotNetCore.CAP" Version="7.0.1" />
+		<PackageReference Include="DotNetCore.CAP" Version="7.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SkyApm.Diagnostics.EntityFrameworkCore/SkyApm.Diagnostics.EntityFrameworkCore.csproj
+++ b/src/SkyApm.Diagnostics.EntityFrameworkCore/SkyApm.Diagnostics.EntityFrameworkCore.csproj
@@ -20,12 +20,12 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.17" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.12" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.13" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.13" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-	    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
-	    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.1" />
+	    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2" />
+	    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.2" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj"/>

--- a/src/SkyApm.Diagnostics.FreeSql/SkyApm.Diagnostics.FreeSql.csproj
+++ b/src/SkyApm.Diagnostics.FreeSql/SkyApm.Diagnostics.FreeSql.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FreeSql" Version="3.2.685" />
+    <PackageReference Include="FreeSql" Version="3.2.687" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />

--- a/src/SkyApm.Diagnostics.Grpc.Net.Client/SkyApm.Diagnostics.Grpc.Net.Client.csproj
+++ b/src/SkyApm.Diagnostics.Grpc.Net.Client/SkyApm.Diagnostics.Grpc.Net.Client.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Grpc.Core.Api" Version="2.47.0" />
+        <PackageReference Include="Grpc.Core.Api" Version="2.51.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SkyApm.Diagnostics.Grpc/SkyApm.Diagnostics.Grpc.csproj
+++ b/src/SkyApm.Diagnostics.Grpc/SkyApm.Diagnostics.Grpc.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc" Version="2.37.0" />
+    <PackageReference Include="Grpc" Version="2.46.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SkyApm.Diagnostics.MongoDB/SkyApm.Diagnostics.MongoDB.csproj
+++ b/src/SkyApm.Diagnostics.MongoDB/SkyApm.Diagnostics.MongoDB.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.19.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/SkyApm.Transport.Grpc.Protocol/SkyApm.Transport.Grpc.Protocol.csproj
+++ b/src/SkyApm.Transport.Grpc.Protocol/SkyApm.Transport.Grpc.Protocol.csproj
@@ -15,9 +15,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.21.5" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.47.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.48.0">
+		<PackageReference Include="Google.Protobuf" Version="3.21.12" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.51.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/SkyApm.Utilities.Configuration/SkyApm.Utilities.Configuration.csproj
+++ b/src/SkyApm.Utilities.Configuration/SkyApm.Utilities.Configuration.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
 	    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0"/>
-	    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.1"/>
+	    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2"/>
 	    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0"/>
 	    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
     </ItemGroup>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues
- 在项目开发中,实际上仅使用一种或者两种数据库,并不需要那么多,比如我的项目中仅使用MongoDB,别的依赖完全就没有用,移除后可减少nuget还原失败的概率,同样可以减少程序大小以及docker镜像包大小.
___
### Bug fix
- Remove non-essential dependencies in SkyApm.Agent.Hosting. Reduce package size. and the size of the docker image after packaging.
- 移除SkyApm.Agent.Hosting项目中非必要的依赖,将EF,Npgsql,MySql,Sqlite以及SqlClient移除,若是用到这些请自行引入相关的nuget包.

- How to fix?
- remove SkyApm.Diagnostics.EntityFrameworkCore.Npgsql
- remove SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql
- remove SkyApm.Diagnostics.EntityFrameworkCore.Sqlite
- remove SkyApm.Diagnostics.EntityFrameworkCore
- remove SkyApm.Diagnostics.SqlClient
- Remove the above dependencies and change the references to be added by the user on demand.
- 移除以上包的默认依赖,使用时,请单独引入.
___
### New feature or improvement
- Describe the details and related test reports.
