### PR TITLE
Support access to ITracingContext through static property.

### DIFF
--- a/skyapm-dotnet.sln
+++ b/skyapm-dotnet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33027.164
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{05BF0D4E-C824-4EC8-8330-36C1FC49910E}"
 EndProject
@@ -114,6 +114,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Sample.Logging", "sample\SkyApm.Sample.Logging\SkyApm.Sample.Logging.csproj", "{136EAD07-A501-4308-9972-82E44F655735}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Diagnostics.MassTransit", "src\SkyApm.Diagnostics.MassTransit\SkyApm.Diagnostics.MassTransit.csproj", "{1C6A8B34-BB6A-44E0-A395-05ADFB094367}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Utilities.StaticAccessor", "src\SkyApm.Utilities.StaticAccessor\SkyApm.Utilities.StaticAccessor.csproj", "{F82B5819-0CED-4C9B-9305-7E62DBFB1219}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -261,6 +263,10 @@ Global
 		{1C6A8B34-BB6A-44E0-A395-05ADFB094367}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C6A8B34-BB6A-44E0-A395-05ADFB094367}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C6A8B34-BB6A-44E0-A395-05ADFB094367}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -310,6 +316,7 @@ Global
 		{4E3BA76C-2A30-4CAD-9F6C-08DF5DF0CE0C} = {B5E677CF-2920-4B0A-A056-E73F6B2CF2BC}
 		{136EAD07-A501-4308-9972-82E44F655735} = {844CEACD-4C85-4B15-9E2B-892B01FDA4BB}
 		{1C6A8B34-BB6A-44E0-A395-05ADFB094367} = {B5E677CF-2920-4B0A-A056-E73F6B2CF2BC}
+		{F82B5819-0CED-4C9B-9305-7E62DBFB1219} = {4BD917BC-D579-4C75-9939-41BF012A4EE2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {94C0DA2C-CCCB-4314-93A2-9809B5DD0583}

--- a/src/SkyApm.Utilities.StaticAccessor/DependencyInjectionExtensions.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/DependencyInjectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using SkyApm.Utilities.StaticAccessor;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class DependencyInjectionExtensions
+    {
+        public static IServiceCollection AddSkyAPMStaticAccessor(this IServiceCollection services)
+        {
+            services.AddHostedService<StaticAccessorHostedService>();
+
+            return services;
+        }
+    }
+}

--- a/src/SkyApm.Utilities.StaticAccessor/DependencyInjectionExtensions.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/DependencyInjectionExtensions.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Utilities.StaticAccessor;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Utilities.StaticAccessor;
 
 namespace Microsoft.Extensions.DependencyInjection
 {

--- a/src/SkyApm.Utilities.StaticAccessor/NullConfigAccessor.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/NullConfigAccessor.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Config;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Config;
 
 namespace SkyApm.Utilities.StaticAccessor
 {

--- a/src/SkyApm.Utilities.StaticAccessor/NullConfigAccessor.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/NullConfigAccessor.cs
@@ -1,0 +1,11 @@
+﻿using SkyApm.Config;
+
+namespace SkyApm.Utilities.StaticAccessor
+{
+    internal class NullConfigAccessor : IConfigAccessor
+    {
+        public T Get<T>() where T : class, new() => new T();
+
+        public T Value<T>(string key, params string[] sections) => default;
+    }
+}

--- a/src/SkyApm.Utilities.StaticAccessor/NullInstances.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/NullInstances.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Tracing.Segments;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing.Segments;
 
 namespace SkyApm.Utilities.StaticAccessor
 {

--- a/src/SkyApm.Utilities.StaticAccessor/NullInstances.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/NullInstances.cs
@@ -1,0 +1,11 @@
+﻿using SkyApm.Tracing.Segments;
+
+namespace SkyApm.Utilities.StaticAccessor
+{
+    public static class NullInstances
+    {
+        public static readonly SegmentSpan SegmentSpan = new SegmentSpan("NULL", SpanType.Local);
+
+        public static readonly SegmentContext SegmentContext = new SegmentContext(string.Empty, string.Empty, false, string.Empty, string.Empty, "NULL", SpanType.Local);
+    }
+}

--- a/src/SkyApm.Utilities.StaticAccessor/NullTracingContext.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/NullTracingContext.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Tracing;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing;
 using SkyApm.Tracing.Segments;
 
 namespace SkyApm.Utilities.StaticAccessor

--- a/src/SkyApm.Utilities.StaticAccessor/NullTracingContext.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/NullTracingContext.cs
@@ -1,0 +1,19 @@
+﻿using SkyApm.Tracing;
+using SkyApm.Tracing.Segments;
+
+namespace SkyApm.Utilities.StaticAccessor
+{
+    internal class NullTracingContext : ITracingContext
+    {
+        public SegmentContext CreateEntrySegmentContext(string operationName, ICarrierHeaderCollection carrierHeader, long startTimeMilliseconds = 0) => NullInstances.SegmentContext;
+
+        public SegmentContext CreateExitSegmentContext(string operationName, string networkAddress, ICarrierHeaderCollection carrierHeader = null, long startTimeMilliseconds = 0) => NullInstances.SegmentContext;
+
+        public SegmentContext CreateLocalSegmentContext(string operationName, long startTimeMilliseconds = 0) => NullInstances.SegmentContext;
+
+        public void Release(SegmentContext segmentContext, long endTimeMilliseconds = 0)
+        {
+
+        }
+    }
+}

--- a/src/SkyApm.Utilities.StaticAccessor/SkyApm.Utilities.StaticAccessor.csproj
+++ b/src/SkyApm.Utilities.StaticAccessor/SkyApm.Utilities.StaticAccessor.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\common.props" />
+  <PropertyGroup>
+    <Description>$(Product) instances accessor.</Description>
+    <AssemblyTitle>$(PackagePrefix).Utilities.StaticAccessor</AssemblyTitle>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <AssemblyName>$(PackagePrefix).Utilities.StaticAccessor</AssemblyName>
+    <PackageId>$(PackagePrefix).Utilities.StaticAccessor</PackageId>
+    <PackageTags>SkyWalking;APM;Diagnostics</PackageTags>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
+    <RootNamespace>SkyApm.Utilities.StaticAccessor</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/SkyApm.Utilities.StaticAccessor/SkyApm.Utilities.StaticAccessor.csproj
+++ b/src/SkyApm.Utilities.StaticAccessor/SkyApm.Utilities.StaticAccessor.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Description>$(Product) instances accessor.</Description>
     <AssemblyTitle>$(PackagePrefix).Utilities.StaticAccessor</AssemblyTitle>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <AssemblyName>$(PackagePrefix).Utilities.StaticAccessor</AssemblyName>
     <PackageId>$(PackagePrefix).Utilities.StaticAccessor</PackageId>
     <PackageTags>SkyWalking;APM;Diagnostics</PackageTags>
@@ -15,13 +15,16 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.32" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />

--- a/src/SkyApm.Utilities.StaticAccessor/SkyApmInstances.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/SkyApmInstances.cs
@@ -1,0 +1,12 @@
+﻿using SkyApm.Config;
+using SkyApm.Tracing;
+
+namespace SkyApm.Utilities.StaticAccessor
+{
+    public static class SkyApmInstances
+    {
+        public static ITracingContext TracingContext { get; internal set; } = new NullTracingContext();
+
+        public static IConfigAccessor ConfigAccessor { get; internal set; } = new NullConfigAccessor();
+    }
+}

--- a/src/SkyApm.Utilities.StaticAccessor/SkyApmInstances.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/SkyApmInstances.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Config;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Config;
 using SkyApm.Tracing;
 
 namespace SkyApm.Utilities.StaticAccessor

--- a/src/SkyApm.Utilities.StaticAccessor/StaticAccessorHostedService.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/StaticAccessorHostedService.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Hosting;
+using SkyApm.Config;
+using SkyApm.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Utilities.StaticAccessor
+{
+    internal class StaticAccessorHostedService : IHostedService
+    {
+        private readonly ITracingContext _tracingContext;
+        private readonly IConfigAccessor _configAccessor;
+
+        public StaticAccessorHostedService(ITracingContext tracingContext, IConfigAccessor configAccessor)
+        {
+            _tracingContext = tracingContext;
+            _configAccessor = configAccessor;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            SkyApmInstances.TracingContext = _tracingContext;
+            SkyApmInstances.ConfigAccessor = _configAccessor;
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SkyApm.Utilities.StaticAccessor/StaticAccessorHostedService.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/StaticAccessorHostedService.cs
@@ -1,4 +1,22 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using Microsoft.Extensions.Hosting;
 using SkyApm.Config;
 using SkyApm.Tracing;
 using System.Threading;

--- a/src/SkyApm.Utilities.StaticAccessor/StaticAccessorHostedService.cs
+++ b/src/SkyApm.Utilities.StaticAccessor/StaticAccessorHostedService.cs
@@ -16,9 +16,11 @@
  *
  */
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SkyApm.Config;
 using SkyApm.Tracing;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,16 +31,19 @@ namespace SkyApm.Utilities.StaticAccessor
         private readonly ITracingContext _tracingContext;
         private readonly IConfigAccessor _configAccessor;
 
-        public StaticAccessorHostedService(ITracingContext tracingContext, IConfigAccessor configAccessor)
+        public StaticAccessorHostedService(IServiceProvider provider)
         {
-            _tracingContext = tracingContext;
-            _configAccessor = configAccessor;
+            _tracingContext = provider.GetService<ITracingContext>();
+            _configAccessor = provider.GetService<IConfigAccessor>();
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            SkyApmInstances.TracingContext = _tracingContext;
-            SkyApmInstances.ConfigAccessor = _configAccessor;
+            if (_tracingContext != null && _configAccessor != null)
+            {
+                SkyApmInstances.TracingContext = _tracingContext;
+                SkyApmInstances.ConfigAccessor = _configAccessor;
+            }
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
The current pr adds the SkyApm.Utilities.StaticAccessor project, which provides static properties for accessing `ITracingContext`, which is convenient for creating a `Segment` in a static method.
有时候我们需要在静态方法中创建`segment`，当前PR中的SkyApm.Utilities.StaticAccessor项目提供了静态属性访问`ITracingContext`

```csharp
// 1. add SkyApm.Utilities.StaticAccessor package reference
// dotnet add package SkyApm.Utilities.StaticAccessor

// 2. enable in startup
public class Startup
{
    public void ConfigureServices(IServiceCollection services)
    {
        // ...

        services.AddSkyAPMStaticAccessor();
    }
}

// 3. use it in static method
static async Task M()
{
    var context = SkyApm.Utilities.StaticAccessor.TracingContext.CreateLocalSegmentContext("test");
    await Task.Delay(100);
    SkyApm.Utilities.StaticAccessor.TracingContext.Release(context);
}
```