### PR TITLE
MSSQL and MySQL peer format can be changed to the same format as java by configuration

### DIFF
--- a/skyapm-dotnet.sln
+++ b/skyapm-dotnet.sln
@@ -117,6 +117,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Diagnostics.MassTran
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Utilities.StaticAccessor", "src\SkyApm.Utilities.StaticAccessor\SkyApm.Utilities.StaticAccessor.csproj", "{F82B5819-0CED-4C9B-9305-7E62DBFB1219}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PeerFormatters", "PeerFormatters", "{D122E6AE-6FE7-4C1A-826F-5964ABBF2C9D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkyApm.PeerFormatters.SqlClient", "src\SkyApm.PeerFormatters.SqlClient\SkyApm.PeerFormatters.SqlClient.csproj", "{5DBE2053-EBAE-404F-A7B3-9CE3CD2152D9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkyApm.PeerFormatters.MySqlConnector", "src\SkyApm.PeerFormatters.MySqlConnector\SkyApm.PeerFormatters.MySqlConnector.csproj", "{2A313B7E-CC41-4556-8055-D87266C398BF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -267,6 +273,14 @@ Global
 		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F82B5819-0CED-4C9B-9305-7E62DBFB1219}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DBE2053-EBAE-404F-A7B3-9CE3CD2152D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DBE2053-EBAE-404F-A7B3-9CE3CD2152D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DBE2053-EBAE-404F-A7B3-9CE3CD2152D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DBE2053-EBAE-404F-A7B3-9CE3CD2152D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A313B7E-CC41-4556-8055-D87266C398BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A313B7E-CC41-4556-8055-D87266C398BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A313B7E-CC41-4556-8055-D87266C398BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A313B7E-CC41-4556-8055-D87266C398BF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -317,6 +331,9 @@ Global
 		{136EAD07-A501-4308-9972-82E44F655735} = {844CEACD-4C85-4B15-9E2B-892B01FDA4BB}
 		{1C6A8B34-BB6A-44E0-A395-05ADFB094367} = {B5E677CF-2920-4B0A-A056-E73F6B2CF2BC}
 		{F82B5819-0CED-4C9B-9305-7E62DBFB1219} = {4BD917BC-D579-4C75-9939-41BF012A4EE2}
+		{D122E6AE-6FE7-4C1A-826F-5964ABBF2C9D} = {05BF0D4E-C824-4EC8-8330-36C1FC49910E}
+		{5DBE2053-EBAE-404F-A7B3-9CE3CD2152D9} = {D122E6AE-6FE7-4C1A-826F-5964ABBF2C9D}
+		{2A313B7E-CC41-4556-8055-D87266C398BF} = {D122E6AE-6FE7-4C1A-826F-5964ABBF2C9D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {94C0DA2C-CCCB-4314-93A2-9809B5DD0583}

--- a/src/SkyApm.Abstractions/Config/TracingConfig.cs
+++ b/src/SkyApm.Abstractions/Config/TracingConfig.cs
@@ -9,6 +9,6 @@ namespace SkyApm.Config
     {
         public int ExceptionMaxDepth { get; set; } = 3;
 
-        public bool JavaDbPeerFormat { get; set; } = false;
+        public bool DbPeerSimpleFormat { get; set; } = false;
     }
 }

--- a/src/SkyApm.Abstractions/Config/TracingConfig.cs
+++ b/src/SkyApm.Abstractions/Config/TracingConfig.cs
@@ -8,5 +8,7 @@ namespace SkyApm.Config
     public class TracingConfig
     {
         public int ExceptionMaxDepth { get; set; } = 3;
+
+        public bool JavaDbPeerFormat { get; set; } = false;
     }
 }

--- a/src/SkyApm.Abstractions/Tracing/IDbPeerFormatter.cs
+++ b/src/SkyApm.Abstractions/Tracing/IDbPeerFormatter.cs
@@ -1,4 +1,22 @@
-﻿using System.Data.Common;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.Data.Common;
 
 namespace SkyApm.Tracing
 {

--- a/src/SkyApm.Abstractions/Tracing/IDbPeerFormatter.cs
+++ b/src/SkyApm.Abstractions/Tracing/IDbPeerFormatter.cs
@@ -1,0 +1,11 @@
+﻿using System.Data.Common;
+
+namespace SkyApm.Tracing
+{
+    public interface IDbPeerFormatter
+    {
+        bool Match(DbConnection connection);
+
+        string GetPeer(DbConnection connection);
+    }
+}

--- a/src/SkyApm.Abstractions/Tracing/IPeerFormatter.cs
+++ b/src/SkyApm.Abstractions/Tracing/IPeerFormatter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Text;
+
+namespace SkyApm.Tracing
+{
+    public interface IPeerFormatter
+    {
+        string GetDbPeer(DbConnection connection);
+    }
+}

--- a/src/SkyApm.Abstractions/Tracing/IPeerFormatter.cs
+++ b/src/SkyApm.Abstractions/Tracing/IPeerFormatter.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Text;

--- a/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -36,6 +36,8 @@ using System;
 using SkyApm;
 using SkyApm.Agent.Hosting;
 using SkyApm.Diagnostics.MSLogging;
+using SkyApm.PeerFormatters.SqlClient;
+using SkyApm.PeerFormatters.MySqlConnector;
 using ILoggerFactory = SkyApm.Logging.ILoggerFactory;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -69,6 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IHostedService, InstrumentationHostedService>();
             services.AddSingleton<IEnvironmentProvider, HostingEnvironmentProvider>();
             services.AddSingleton<ISkyApmLogDispatcher, AsyncQueueSkyApmLogDispatcher>();
+            services.AddSingleton<IPeerFormatter, PeerFormatter>();
             services.AddTracing().AddSampling().AddGrpcTransport().AddSkyApmLogging();
             var extensions = services.AddSkyApmExtensions()
                 .AddHttpClient()
@@ -76,7 +79,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSqlClient()
                 .AddGrpc()
                 .AddEntityFrameworkCore(c => c.AddPomeloMysql().AddNpgsql().AddSqlite())
-                .AddMSLogging();
+                .AddMSLogging()
+                .AddSqlClientPeerFormatter()
+                .AddMySqlConnectorPeerFormatter();
 
             extensionsSetup?.Invoke(extensions);
 

--- a/src/SkyApm.Agent.Hosting/SkyApm.Agent.Hosting.csproj
+++ b/src/SkyApm.Agent.Hosting/SkyApm.Agent.Hosting.csproj
@@ -35,6 +35,8 @@
         <ProjectReference Include="..\SkyApm.Diagnostics.HttpClient\SkyApm.Diagnostics.HttpClient.csproj" />
         <ProjectReference Include="..\SkyApm.Diagnostics.MSLogging\SkyApm.Diagnostics.MSLogging.csproj" />
         <ProjectReference Include="..\SkyApm.Diagnostics.SqlClient\SkyApm.Diagnostics.SqlClient.csproj" />
+		<ProjectReference Include="..\SkyApm.PeerFormatters.MySqlConnector\SkyApm.PeerFormatters.MySqlConnector.csproj" />
+		<ProjectReference Include="..\SkyApm.PeerFormatters.SqlClient\SkyApm.PeerFormatters.SqlClient.csproj" />
         <ProjectReference Include="..\SkyApm.Transport.Grpc\SkyApm.Transport.Grpc.csproj" />
         <ProjectReference Include="..\SkyApm.Utilities.Configuration\SkyApm.Utilities.Configuration.csproj" />
         <ProjectReference Include="..\SkyApm.Utilities.DependencyInjection\SkyApm.Utilities.DependencyInjection.csproj" />

--- a/src/SkyApm.Core/Tracing/PeerFormatter.cs
+++ b/src/SkyApm.Core/Tracing/PeerFormatter.cs
@@ -1,6 +1,24 @@
 ﻿using SkyApm.Config;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 using System.Data.Common;
 
 namespace SkyApm.Tracing

--- a/src/SkyApm.Core/Tracing/PeerFormatter.cs
+++ b/src/SkyApm.Core/Tracing/PeerFormatter.cs
@@ -38,7 +38,7 @@ namespace SkyApm.Tracing
 
         public string GetDbPeer(DbConnection connection)
         {
-            if (!_tracingConfig.JavaDbPeerFormat) return connection.DataSource;
+            if (!_tracingConfig.DbPeerSimpleFormat) return connection.DataSource;
 
             return _peerMap.GetOrAdd($"{connection.GetType()}_{connection.DataSource}", k =>
             {

--- a/src/SkyApm.Core/Tracing/PeerFormatter.cs
+++ b/src/SkyApm.Core/Tracing/PeerFormatter.cs
@@ -1,0 +1,39 @@
+﻿using SkyApm.Config;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace SkyApm.Tracing
+{
+    public class PeerFormatter : IPeerFormatter
+    {
+        private readonly ConcurrentDictionary<string, string> _peerMap = new ConcurrentDictionary<string, string>();
+
+        private readonly IEnumerable<IDbPeerFormatter> _dbPeerFormatters;
+        private readonly TracingConfig _tracingConfig;
+
+        public PeerFormatter(IEnumerable<IDbPeerFormatter> dbPeerFormatters, IConfigAccessor configAccessor)
+        {
+            _dbPeerFormatters= dbPeerFormatters;
+            _tracingConfig = configAccessor.Get<TracingConfig>();
+        }
+
+        public string GetDbPeer(DbConnection connection)
+        {
+            if (!_tracingConfig.JavaDbPeerFormat) return connection.DataSource;
+
+            return _peerMap.GetOrAdd($"{connection.GetType()}_{connection.DataSource}", k =>
+            {
+                foreach (var formatter in _dbPeerFormatters)
+                {
+                    if (formatter.Match(connection))
+                    {
+                        return formatter.GetPeer(connection);
+                    }
+                }
+
+                return connection.DataSource;
+            });
+        }
+    }
+}

--- a/src/SkyApm.Diagnostics.EntityFrameworkCore.Npgsql/NpgsqlEntityFrameworkCoreSpanMetadataProvider.cs
+++ b/src/SkyApm.Diagnostics.EntityFrameworkCore.Npgsql/NpgsqlEntityFrameworkCoreSpanMetadataProvider.cs
@@ -17,12 +17,20 @@
  */
 
 using SkyApm.Common;
+using SkyApm.Tracing;
 using System.Data.Common;
 
 namespace SkyApm.Diagnostics.EntityFrameworkCore
 {
     public class NpgsqlEntityFrameworkCoreSpanMetadataProvider : IEntityFrameworkCoreSpanMetadataProvider
     {
+        private readonly IPeerFormatter _peerFormatter;
+
+        public NpgsqlEntityFrameworkCoreSpanMetadataProvider(IPeerFormatter peerFormatter)
+        {
+            _peerFormatter = peerFormatter;
+        }
+
         public StringOrIntValue Component { get; } = Common.Components.NPGSQL_ENTITYFRAMEWORKCORE_POSTGRESQL;
 
         public bool Match(DbConnection connection)
@@ -32,7 +40,7 @@ namespace SkyApm.Diagnostics.EntityFrameworkCore
 
         public string GetPeer(DbConnection connection)
         {
-            return connection.DataSource;
+            return _peerFormatter.GetDbPeer(connection);
         }
     }
 }

--- a/src/SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql/MySqlEntityFrameworkCoreSpanMetadataProvider.cs
+++ b/src/SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql/MySqlEntityFrameworkCoreSpanMetadataProvider.cs
@@ -17,12 +17,20 @@
  */
 
 using SkyApm.Common;
+using SkyApm.Tracing;
 using System.Data.Common;
 
 namespace SkyApm.Diagnostics.EntityFrameworkCore
 {
     public class MySqlEntityFrameworkCoreSpanMetadataProvider : IEntityFrameworkCoreSpanMetadataProvider
     {
+        private readonly IPeerFormatter _peerFormatter;
+
+        public MySqlEntityFrameworkCoreSpanMetadataProvider(IPeerFormatter peerFormatter)
+        {
+            _peerFormatter = peerFormatter;
+        }
+
         public StringOrIntValue Component { get; } = Common.Components.POMELO_ENTITYFRAMEWORKCORE_MYSQL;
         
         public bool Match(DbConnection connection)
@@ -32,7 +40,7 @@ namespace SkyApm.Diagnostics.EntityFrameworkCore
 
         public string GetPeer(DbConnection connection)
         {
-            return connection.DataSource;
+            return _peerFormatter.GetDbPeer(connection);
         }
     }
 }

--- a/src/SkyApm.Diagnostics.EntityFrameworkCore.Sqlite/SqliteEntityFrameworkCoreSpanMetadataProvider.cs
+++ b/src/SkyApm.Diagnostics.EntityFrameworkCore.Sqlite/SqliteEntityFrameworkCoreSpanMetadataProvider.cs
@@ -17,12 +17,20 @@
  */
 
 using SkyApm.Common;
+using SkyApm.Tracing;
 using System.Data.Common;
 
 namespace SkyApm.Diagnostics.EntityFrameworkCore
 {
     public class SqliteEntityFrameworkCoreSpanMetadataProvider : IEntityFrameworkCoreSpanMetadataProvider
     {
+        private readonly IPeerFormatter _peerFormatter;
+
+        public SqliteEntityFrameworkCoreSpanMetadataProvider(IPeerFormatter peerFormatter)
+        {
+            _peerFormatter = peerFormatter;
+        }
+
         public StringOrIntValue Component { get; } = Common.Components.ENTITYFRAMEWORKCORE_SQLITE;
 
         public bool Match(DbConnection connection)
@@ -32,18 +40,13 @@ namespace SkyApm.Diagnostics.EntityFrameworkCore
 
         public string GetPeer(DbConnection connection)
         {
-            string dataSource;
             switch (connection.DataSource)
             {
                 case "":
-                    dataSource = "sqlite:memory:db";
-                    break;
+                    return "sqlite:memory:db";
                 default:
-                    dataSource = connection.DataSource;
-                    break;
+                    return _peerFormatter.GetDbPeer(connection);
             }
-
-            return $"{dataSource}";
         }
     }
 }

--- a/src/SkyApm.Diagnostics.SmartSql/SmartSqlTracingDiagnosticProcessor.cs
+++ b/src/SkyApm.Diagnostics.SmartSql/SmartSqlTracingDiagnosticProcessor.cs
@@ -37,13 +37,16 @@ namespace SkyApm.Diagnostics.SmartSql
         private readonly ITracingContext _tracingContext;
         private readonly ILocalSegmentContextAccessor _localSegmentContextAccessor;
         private readonly TracingConfig _tracingConfig;
+        private readonly IPeerFormatter _peerFormatter;
 
         public SmartSqlTracingDiagnosticProcessor(ITracingContext tracingContext,
-            ILocalSegmentContextAccessor localSegmentContextAccessor, IConfigAccessor configAccessor)
+            ILocalSegmentContextAccessor localSegmentContextAccessor, IConfigAccessor configAccessor,
+            IPeerFormatter peerFormatter)
         {
             _tracingContext = tracingContext;
             _localSegmentContextAccessor = localSegmentContextAccessor;
             _tracingConfig = configAccessor.Get<TracingConfig>();
+            _peerFormatter = peerFormatter;
         }
         private void AddConnectionTag(SegmentContext context, DbConnection dbConnection)
         {
@@ -53,7 +56,7 @@ namespace SkyApm.Diagnostics.SmartSql
             }
             if (dbConnection.DataSource != null)
             {
-                context.Span.Peer = new Common.StringOrIntValue(dbConnection.DataSource);
+                context.Span.Peer = _peerFormatter.GetDbPeer(dbConnection);
             }
             if (dbConnection.Database != null)
             {

--- a/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatter.cs
+++ b/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatter.cs
@@ -1,0 +1,42 @@
+﻿using SkyApm.Tracing;
+using System.Data.Common;
+using System.Text.RegularExpressions;
+
+namespace SkyApm.PeerFormatters.MySqlConnector
+{
+    internal class MySqlConnectorPeerFormatter : IDbPeerFormatter
+    {
+        private readonly Regex _serverRegex = new Regex(@"server=(?:([^;]+?);|([^;]+?)$)", RegexOptions.IgnoreCase);
+        private readonly Regex _portRegex = new Regex(@"port=(\d+)");
+
+        public bool Match(DbConnection connection)
+        {
+            var fullName = connection.GetType().FullName;
+            return fullName == "MySql.Data.MySqlClient.MySqlConnection" || fullName == "MySqlConnector.MySqlConnection";
+        }
+
+        public string GetPeer(DbConnection connection)
+        {
+            if (connection.ConnectionString == null) return connection.DataSource;
+
+            var serverMatch = _serverRegex.Match(connection.ConnectionString);
+            var portMatch = _portRegex.Match(connection.ConnectionString);
+
+            var port = portMatch.Success ? portMatch.Groups[1].Value : "3306";
+
+            if (serverMatch.Success && serverMatch.Groups.Count == 3)
+            {
+                if (serverMatch.Groups[1].Success)
+                {
+                    return $"{serverMatch.Groups[1].Value}:{port}";
+                }
+                if (serverMatch.Groups[2].Success)
+                {
+                    return $"{serverMatch.Groups[2].Value}:{port}";
+                }
+            }
+
+            return connection.DataSource;
+        }
+    }
+}

--- a/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatter.cs
+++ b/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatter.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Tracing;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing;
 using System.Data.Common;
 using System.Text.RegularExpressions;
 

--- a/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatterExtensions.cs
+++ b/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatterExtensions.cs
@@ -1,4 +1,22 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SkyApm.Tracing;
 using SkyApm.Utilities.DependencyInjection;

--- a/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatterExtensions.cs
+++ b/src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatterExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using SkyApm.Tracing;
+using SkyApm.Utilities.DependencyInjection;
+using System;
+
+namespace SkyApm.PeerFormatters.MySqlConnector
+{
+    public static class MySqlConnectorPeerFormatterExtensions
+    {
+        public static SkyApmExtensions AddMySqlConnectorPeerFormatter(this SkyApmExtensions extensions)
+        {
+            if (extensions == null)
+            {
+                throw new ArgumentNullException(nameof(extensions));
+            }
+
+            extensions.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IDbPeerFormatter, MySqlConnectorPeerFormatter>());
+
+            return extensions;
+        }
+    }
+}

--- a/src/SkyApm.PeerFormatters.MySqlConnector/SkyApm.PeerFormatters.MySqlConnector.csproj
+++ b/src/SkyApm.PeerFormatters.MySqlConnector/SkyApm.PeerFormatters.MySqlConnector.csproj
@@ -10,7 +10,7 @@
     <PackageReleaseNotes>
     </PackageReleaseNotes>
     <RootNamespace>SkyApm.PeerFormatters.MySqlConnector</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SkyApm.PeerFormatters.MySqlConnector/SkyApm.PeerFormatters.MySqlConnector.csproj
+++ b/src/SkyApm.PeerFormatters.MySqlConnector/SkyApm.PeerFormatters.MySqlConnector.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
+	
+  <PropertyGroup>
+    <Description>$(Product) MySqlConnector peer formatter.</Description>
+    <AssemblyTitle>$(PackagePrefix).PeerFormatters.MySqlConnector</AssemblyTitle>
+    <AssemblyName>$(PackagePrefix).PeerFormatters.MySqlConnector</AssemblyName>
+    <PackageId>$(PackagePrefix).PeerFormatters.MySqlConnector</PackageId>
+    <PackageTags>SkyWalking;APM;MySqlConnector</PackageTags>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
+    <RootNamespace>SkyApm.PeerFormatters.MySqlConnector</RootNamespace>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />
+    <ProjectReference Include="..\SkyApm.Utilities.DependencyInjection\SkyApm.Utilities.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SkyApm.PeerFormatters.SqlClient/SkyApm.PeerFormatters.SqlClient.csproj
+++ b/src/SkyApm.PeerFormatters.SqlClient/SkyApm.PeerFormatters.SqlClient.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props" />
+	
+  <PropertyGroup>
+    <Description>$(Product) System.Data.SqlClient and Microsoft.Data.SqlClient peer formatter.</Description>
+    <AssemblyTitle>$(PackagePrefix).PeerFormatters.SqlClient</AssemblyTitle>
+    <AssemblyName>$(PackagePrefix).PeerFormatters.SqlClient</AssemblyName>
+    <PackageId>$(PackagePrefix).PeerFormatters.SqlClient</PackageId>
+    <PackageTags>SkyWalking;APM;SqlClient</PackageTags>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
+    <RootNamespace>SkyApm.PeerFormatters.SqlClient</RootNamespace>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />
+    <ProjectReference Include="..\SkyApm.Utilities.DependencyInjection\SkyApm.Utilities.DependencyInjection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SkyApm.PeerFormatters.SqlClient/SkyApm.PeerFormatters.SqlClient.csproj
+++ b/src/SkyApm.PeerFormatters.SqlClient/SkyApm.PeerFormatters.SqlClient.csproj
@@ -10,7 +10,7 @@
     <PackageReleaseNotes>
     </PackageReleaseNotes>
     <RootNamespace>SkyApm.PeerFormatters.SqlClient</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatter.cs
+++ b/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatter.cs
@@ -1,0 +1,46 @@
+﻿using SkyApm.Tracing;
+using System.Data.Common;
+using System.Text.RegularExpressions;
+
+namespace SkyApm.PeerFormatters.SqlClient
+{
+    internal class SqlClientPeerFormatter : IDbPeerFormatter
+    {
+        private readonly Regex _conStrRegex = new Regex(@"Data Source=(?:([^;,]+?)(?:,(\d+))?;|([^,]+?)(?:,(\d+))?$)", RegexOptions.IgnoreCase);
+
+        public bool Match(DbConnection connection)
+        {
+            var fullName = connection.GetType().FullName;
+            return fullName == "System.Data.SqlClient.SqlConnection" || fullName == "Microsoft.Data.SqlClient.SqlConnection";
+        }
+
+        public string GetPeer(DbConnection connection)
+        {
+            if (connection.ConnectionString == null) return connection.DataSource;
+
+            var match = _conStrRegex.Match(connection.ConnectionString);
+
+            if (match.Success && match.Groups.Count == 5)
+            {
+                if (match.Groups[1].Success)
+                {
+                    if (match.Groups[2].Success)
+                    {
+                        return $"{match.Groups[1].Value}:{match.Groups[2].Value}";
+                    }
+                    return match.Groups[1].Value + ":1433";
+                }
+                if (match.Groups[3].Success)
+                {
+                    if (match.Groups[4].Success)
+                    {
+                        return $"{match.Groups[3].Value}:{match.Groups[4].Value}";
+                    }
+                    return match.Groups[3].Value + ":1433";
+                }
+            }
+
+            return connection.DataSource;
+        }
+    }
+}

--- a/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatter.cs
+++ b/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatter.cs
@@ -1,4 +1,22 @@
-﻿using SkyApm.Tracing;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing;
 using System.Data.Common;
 using System.Text.RegularExpressions;
 

--- a/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatterExtensions.cs
+++ b/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatterExtensions.cs
@@ -1,4 +1,22 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using SkyApm.Tracing;
 using SkyApm.Utilities.DependencyInjection;

--- a/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatterExtensions.cs
+++ b/src/SkyApm.PeerFormatters.SqlClient/SqlClientPeerFormatterExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using SkyApm.Tracing;
+using SkyApm.Utilities.DependencyInjection;
+using System;
+
+namespace SkyApm.PeerFormatters.SqlClient
+{
+    public static class SqlClientPeerFormatterExtensions
+    {
+        public static SkyApmExtensions AddSqlClientPeerFormatter(this SkyApmExtensions extensions)
+        {
+            if (extensions == null)
+            {
+                throw new ArgumentNullException(nameof(extensions));
+            }
+
+            extensions.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IDbPeerFormatter, SqlClientPeerFormatter>());
+
+            return extensions;
+        }
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
The database peer format in java is unified as [`host:port`](https://github.com/apache/skywalking-java/blob/20c8b98cd9a37ae8a0dce3f45927a947d93361de/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/trace/ConnectionInfo.java#L44-L49)
```java
    public ConnectionInfo(OfficialComponent component, String dbType, String host, int port, String databaseName) {
        this.dbType = dbType;
        this.databasePeer = host + ":" + port;
        this.databaseName = databaseName;
        this.component = component;
    }
```

But in .NET, `DbConnection.DataSource` is generally used directly, and this format is generally not `host:port`. Different formats of the same database peer in .NET and Java will result in separate statistics for virtual databases. I've only changed the format for MSSQL and MySQL so far because I only use those two.

java agent数据库采集部分peer采用了统一的格式`host:port`，.NET中一般直接使用`DbConnection.DataSource`，格式基本都不是`host:port`，如果.NET和java使用同一个库，最后在虚拟数据库界面上会显示两个实例，这个PR增加了一个配置可以支持使用java agent相同的格式，默认还是之前的格式。这个PR中只支持MSSQL和MySQL，其他数据库我没用到就先不改了。

```js
{
  "SkyWalking": {
    "Tracing": {
      "DbPeerSimpleFormat": false      // default false
    }
  }
}
```