### PR TITLE
Use config to control log report level and enrich log message

### DIFF
--- a/src/SkyApm.Abstractions/Config/DiagnosticsLoggingConfig.cs
+++ b/src/SkyApm.Abstractions/Config/DiagnosticsLoggingConfig.cs
@@ -18,10 +18,10 @@
 
 namespace SkyApm.Config
 {
-    [Config("SkyWalking", "LogCollector")]
-    public class LogCollectorConfig
+    [Config("SkyWalking", "Diagnostics", "Logging")]
+    public class DiagnosticsLoggingConfig
     {
-        public LogCollectLevel Level { get; set; } = LogCollectLevel.Information;
+        public LogCollectLevel CollectLevel { get; set; } = LogCollectLevel.Information;
     }
 
     public enum LogCollectLevel

--- a/src/SkyApm.Abstractions/Config/LogCollectorConfig.cs
+++ b/src/SkyApm.Abstractions/Config/LogCollectorConfig.cs
@@ -18,8 +18,20 @@
 
 namespace SkyApm.Config
 {
-    public class LogPushSkywalkingConfig
+    [Config("SkyWalking", "LogCollector")]
+    public class LogCollectorConfig
     {
-        public bool Enable { get; set; }
+        public LogCollectLevel Level { get; set; } = LogCollectLevel.Information;
+    }
+
+    public enum LogCollectLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Information = 2,
+        Warning = 3,
+        Error = 4,
+        Critical = 5,
+        None = 6
     }
 }

--- a/src/SkyApm.Diagnostics.MSLogging/SkyApmLogger.cs
+++ b/src/SkyApm.Diagnostics.MSLogging/SkyApmLogger.cs
@@ -35,7 +35,7 @@ namespace SkyApm.Diagnostics.MSLogging
         private readonly ISegmentContextAccessor _segmentContextAccessor;
         private readonly IEntrySegmentContextAccessor _entrySegmentContextAccessor;
         private readonly TracingConfig _tracingConfig;
-        private readonly LogCollectorConfig _logCollectorConfig;
+        private readonly DiagnosticsLoggingConfig _logCollectorConfig;
 
         public SkyApmLogger(string categoryName, ISkyApmLogDispatcher skyApmLogDispatcher,
             ISegmentContextAccessor segmentContextAccessor,
@@ -47,7 +47,7 @@ namespace SkyApm.Diagnostics.MSLogging
             _segmentContextAccessor = segmentContextAccessor;
             _entrySegmentContextAccessor = entrySegmentContextAccessor;
             _tracingConfig = configAccessor.Get<TracingConfig>();
-            _logCollectorConfig = configAccessor.Get<LogCollectorConfig>();
+            _logCollectorConfig = configAccessor.Get<DiagnosticsLoggingConfig>();
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
@@ -90,7 +90,7 @@ namespace SkyApm.Diagnostics.MSLogging
             _skyApmLogDispatcher.Dispatch(logContext);
         }
 
-        public bool IsEnabled(LogLevel logLevel) => (int)logLevel >= (int)_logCollectorConfig.Level;
+        public bool IsEnabled(LogLevel logLevel) => (int)logLevel >= (int)_logCollectorConfig.CollectLevel;
 
         public IDisposable BeginScope<TState>(TState state) => default!;
     }

--- a/src/SkyApm.Diagnostics.MSLogging/SkyApmLogger.cs
+++ b/src/SkyApm.Diagnostics.MSLogging/SkyApmLogger.cs
@@ -35,6 +35,7 @@ namespace SkyApm.Diagnostics.MSLogging
         private readonly ISegmentContextAccessor _segmentContextAccessor;
         private readonly IEntrySegmentContextAccessor _entrySegmentContextAccessor;
         private readonly TracingConfig _tracingConfig;
+        private readonly LogCollectorConfig _logCollectorConfig;
 
         public SkyApmLogger(string categoryName, ISkyApmLogDispatcher skyApmLogDispatcher,
             ISegmentContextAccessor segmentContextAccessor,
@@ -46,11 +47,14 @@ namespace SkyApm.Diagnostics.MSLogging
             _segmentContextAccessor = segmentContextAccessor;
             _entrySegmentContextAccessor = entrySegmentContextAccessor;
             _tracingConfig = configAccessor.Get<TracingConfig>();
+            _logCollectorConfig = configAccessor.Get<LogCollectorConfig>();
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
+            if (!IsEnabled(logLevel)) return;
+
             var tags = new Dictionary<string, object>
             {
                 { "logger", _categoryName },
@@ -86,7 +90,7 @@ namespace SkyApm.Diagnostics.MSLogging
             _skyApmLogDispatcher.Dispatch(logContext);
         }
 
-        public bool IsEnabled(LogLevel logLevel) => true;
+        public bool IsEnabled(LogLevel logLevel) => (int)logLevel >= (int)_logCollectorConfig.Level;
 
         public IDisposable BeginScope<TState>(TState state) => default!;
     }

--- a/src/SkyApm.Diagnostics.MSLogging/SkyApmLogger.cs
+++ b/src/SkyApm.Diagnostics.MSLogging/SkyApmLogger.cs
@@ -58,7 +58,7 @@ namespace SkyApm.Diagnostics.MSLogging
             var tags = new Dictionary<string, object>
             {
                 { "logger", _categoryName },
-                { "Level", logLevel },
+                { "level", logLevel },
                 { "thread", Thread.CurrentThread.ManagedThreadId },
             };
             if (exception != null)

--- a/src/SkyApm.Diagnostics.MSLogging/SkyApmLoggerProvider.cs
+++ b/src/SkyApm.Diagnostics.MSLogging/SkyApmLoggerProvider.cs
@@ -18,6 +18,7 @@
 
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using SkyApm.Config;
 using SkyApm.Tracing;
 using SkyApm.Transport;
 
@@ -29,14 +30,17 @@ namespace SkyApm.Diagnostics.MSLogging
         private readonly ISkyApmLogDispatcher _skyApmLogDispatcher;
         private readonly ISegmentContextAccessor _segmentContextAccessor;
         private readonly IEntrySegmentContextAccessor _entrySegmentContextAccessor;
+        private readonly IConfigAccessor _configAccessor;
 
         public SkyApmLoggerProvider(ISkyApmLogDispatcher skyApmLogDispatcher,
             ISegmentContextAccessor segmentContextAccessor,
-            IEntrySegmentContextAccessor entrySegmentContextAccessor)
+            IEntrySegmentContextAccessor entrySegmentContextAccessor,
+            IConfigAccessor configAccessor)
         {
             _skyApmLogDispatcher = skyApmLogDispatcher;
             _segmentContextAccessor = segmentContextAccessor;
             _entrySegmentContextAccessor = entrySegmentContextAccessor;
+            _configAccessor = configAccessor;
         }
 
         public void Dispose()
@@ -46,7 +50,7 @@ namespace SkyApm.Diagnostics.MSLogging
         public ILogger CreateLogger(string categoryName)
         {
             return _doveLoggers.GetOrAdd(categoryName,
-                _ => new SkyApmLogger(categoryName, _skyApmLogDispatcher, _segmentContextAccessor, _entrySegmentContextAccessor));
+                _ => new SkyApmLogger(categoryName, _skyApmLogDispatcher, _segmentContextAccessor, _entrySegmentContextAccessor, _configAccessor));
         }
     }
 }


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [ ] Bug fix
- [ ] New feature provided
- [x] Improve performance

- Related issues

___
### Bug fix
- Bug description.

- How to fix?

___
### New feature or improvement
- Describe the details and related test reports.
1. Append Exception detail into log message if exception is not null.
2. Now we can use config key `SkyWalking::LogCollector::Level` to control log collect level. It's useful if someone does not wanna collect log data or only want to collect error log data.
```json
{
  "SkyWalking": {
    "LogCollector": {
      "Level": "Information" // default
    }
  }
}
```