### PR TITLE
bugfix for dependencies of SkyApm.Diagnostics.MassTransit

### DIFF
--- a/src/SkyApm.Diagnostics.MassTransit/SkyApm.Diagnostics.MassTransit.csproj
+++ b/src/SkyApm.Diagnostics.MassTransit/SkyApm.Diagnostics.MassTransit.csproj
@@ -8,9 +8,12 @@
     <ItemGroup>
         <PackageReference Include="MassTransit.Abstractions" Version="8.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
-        <PackageReference Include="SkyAPM.Agent.Hosting" Version="2.0.0" />
-        <PackageReference Include="SkyAPM.Diagnostics.AspNetCore" Version="2.0.0" />
-        <PackageReference Include="SkyAPM.Utilities.DependencyInjection" Version="2.0.0" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\SkyAPM.Agent.Hosting\SkyAPM.Agent.Hosting.csproj" />
+        <ProjectReference Include="..\SkyAPM.Diagnostics.AspNetCore\SkyAPM.Diagnostics.AspNetCore.csproj" />
+        <ProjectReference Include="..\SkyApm.Utilities.DependencyInjection\SkyApm.Utilities.DependencyInjection.csproj" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?

Bug fix.

- Bug description.

SkyApm.Diagnostics.MassTransit shall use ProjectReference rather than PackageReference.
