### PR TITLE
fix(docs): remove duplicate page heading

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -2,9 +2,6 @@
 title: SkyAPM .NET Agent
 toc: false
 ---
-
-# SkyAPM .NET Agent
-
 **SkyAPM-dotnet** is a community, open-source **.NET auto-instrumentation agent** for the .NET ecosystem — distributed tracing, service topology, and metrics for ASP.NET Core and .NET apps, reported to an [Apache SkyWalking](https://skywalking.apache.org/) backend over the **sw8 / v8** protocol. It is an independent project (not an Apache/SkyWalking sub-project) and targets **net8.0** and **net10.0**.
 
 {{< cards >}}

--- a/content/docs/Supported-list.md
+++ b/content/docs/Supported-list.md
@@ -2,9 +2,6 @@
 title: "Supported Components"
 weight: 2
 ---
-
-# Supported components
-
 This page lists the libraries and frameworks that the SkyAPM .NET agent can
 auto-instrument, what each one captures, and whether it is enabled by default or
 must be opted in. SkyAPM-dotnet is the C#/.NET auto-instrumentation agent for

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,9 +2,6 @@
 title: "Documentation"
 weight: 1
 ---
-
-# SkyAPM .NET Agent Documentation
-
 **SkyAPM-dotnet** is a community, open-source **.NET auto-instrumentation agent** for the .NET ecosystem. It provides distributed tracing, application topology, metrics, and log correlation for ASP.NET Core and .NET hosted applications, and reports the collected telemetry to an [Apache SkyWalking](https://skywalking.apache.org/) backend. It is an independent project, not an Apache Software Foundation or SkyWalking sub-project.
 
 The agent targets `net8.0` and `net10.0` (the active .NET LTS releases); foundational libraries also build for `netstandard2.0`. Apps on newer runtimes (e.g. `net9.0`) are covered via the `net8.0` assemblies. The current version is **2.3.0**.

--- a/content/docs/guides/cli.md
+++ b/content/docs/guides/cli.md
@@ -2,9 +2,6 @@
 title: "CLI"
 weight: 8
 ---
-
-# SkyApm.DotNet.CLI
-
 `SkyApm.DotNet.CLI` is a [.NET global tool](https://learn.microsoft.com/dotnet/core/tools/global-tools) that scaffolds the configuration file for the SkyAPM .NET agent. It generates a ready-to-edit `skyapm.json` so you do not have to author the configuration by hand.
 
 ## Install

--- a/content/docs/guides/getting-started.md
+++ b/content/docs/guides/getting-started.md
@@ -2,9 +2,6 @@
 title: "Getting Started"
 weight: 1
 ---
-
-# Getting Started
-
 This quickstart walks you through instrumenting an ASP.NET Core application with the
 SkyAPM .NET agent end to end: stand up a SkyWalking OAP backend, install the package,
 generate a config file, activate the agent with a single environment variable, then send

--- a/content/docs/guides/how-to-build.md
+++ b/content/docs/guides/how-to-build.md
@@ -1,4 +1,3 @@
-# How to build project
 
 This document helps people to compile and build the SkyAPM-dotnet project from source.
 

--- a/content/docs/guides/installation.md
+++ b/content/docs/guides/installation.md
@@ -2,9 +2,6 @@
 title: "Installation & Activation"
 weight: 2
 ---
-
-# Installation
-
 This guide explains how to attach the SkyAPM .NET agent to your application and how
 instrumentation plugins are enabled. SkyAPM-dotnet is a C#/.NET auto-instrumentation
 agent for the .NET ecosystem; it reports traces and logs to an Apache SkyWalking OAP backend over gRPC

--- a/content/docs/guides/logging.md
+++ b/content/docs/guides/logging.md
@@ -2,9 +2,6 @@
 title: "Logging"
 weight: 7
 ---
-
-# Logging
-
 The SkyAPM .NET agent deals with logs in two completely separate ways, and it is
 important not to confuse them:
 

--- a/content/docs/guides/plugins.md
+++ b/content/docs/guides/plugins.md
@@ -2,9 +2,6 @@
 title: "Plugins"
 weight: 6
 ---
-
-# Plugins
-
 The SkyAPM .NET agent ships **16 diagnostic plugins** that auto-instrument common
 frameworks and libraries. Each plugin observes a `DiagnosticListener` / `ActivitySource`
 (or registers an interceptor) and produces SkyWalking **sw8 / v8** spans that the agent

--- a/content/docs/guides/skyapm_config.md
+++ b/content/docs/guides/skyapm_config.md
@@ -2,9 +2,6 @@
 title: "Configuration Reference"
 weight: 3
 ---
-
-# SkyAPM .NET Agent Configuration Reference
-
 This is the authoritative configuration reference for the SkyAPM .NET agent
 (SkyAPM-dotnet) — a C#/.NET auto-instrumentation agent for the .NET ecosystem that reports to an Apache SkyWalking backend.
 Every key lives under the top-level `SkyWalking` root and reports to the

--- a/content/docs/guides/skyapm_config_cn.md
+++ b/content/docs/guides/skyapm_config_cn.md
@@ -2,9 +2,6 @@
 title: "配置参考（中文）"
 weight: 4
 ---
-
-# SkyAPM .NET agent 配置参考
-
 本文档是 SkyAPM .NET agent（SkyAPM-dotnet，面向 Apache SkyWalking 的 C#/.NET 自动埋点探针）的权威配置参考。文档列出全部配置项及其类型、默认值与含义，说明配置的加载顺序与环境变量覆盖规则，并在结尾给出一份完整、正确的 `skyapm.json` 示例。英文版本见 [Configuration Reference](skyapm_config.md)。
 
 ## 概览

--- a/content/docs/guides/transports.md
+++ b/content/docs/guides/transports.md
@@ -2,9 +2,6 @@
 title: "Transports"
 weight: 5
 ---
-
-# Transports (Reporters)
-
 The SkyAPM .NET agent buffers the tracing, metrics, profiling, management, and
 log data it collects, then ships it to the SkyWalking OAP backend through a
 **transport** (also called a **reporter**). This guide explains how to pick a

--- a/content/docs/guides/troubleshooting.md
+++ b/content/docs/guides/troubleshooting.md
@@ -2,9 +2,6 @@
 title: "Troubleshooting"
 weight: 9
 ---
-
-# Troubleshooting & FAQ
-
 Common problems when running the SkyAPM .NET agent and how to fix them. Each
 item follows a **symptom → cause → fix** shape. For configuration reference see
 [Configuration](skyapm_config.md); the docs index is [docs/README.md](/docs/).


### PR DESCRIPTION
## Problem

On the published docs site every page showed its title **twice** — e.g. the home page rendered "SkyAPM .NET Agent" two times in a row.

**Cause:** the Hextra theme renders the front-matter `title` as the page `<h1>`, but each Markdown page also began with its own `# Heading` in the body → two identical H1s.

## Fix

Remove the redundant leading body `# H1` from all 13 content pages; the heading now comes solely from the front-matter `title` (one `<h1>` per page).

✅ Verified with `hugo --gc`: exactly one `<h1>` per page (home, docs index, and guide pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)