### PR TITLE
docs: add robots.txt with sitemap for search indexing

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,7 @@ title = "SkyAPM .NET Agent"
 theme = "hextra"
 enableGitInfo = true
 enableInlineShortcodes = true
+enableRobotsTXT = true
 
 [markup]
   [markup.highlight]

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
Make the docs site discoverable by search engines.

- Enable `enableRobotsTXT` and add `layouts/robots.txt` that allows all crawlers and references the sitemap:
  ```
  User-agent: *
  Allow: /
  Sitemap: https://skyapm.github.io/SkyAPM-dotnet/sitemap.xml
  ```
- `sitemap.xml` (16 URLs) is already auto-generated by Hugo; pages have no `noindex`.

For reliable/fast indexing, the site should also be added to Google Search Console (URL-prefix property) with the sitemap submitted — a one-time manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)