### PR TITLE
Plan: plugin cross-version testing + automated NuGet release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+# Publishes all NuGet packages + a GitHub Release when a vX.Y.Z tag is pushed.
+# Requires the NUGET_API_KEY secret (see RELEASING.md). The strong-name key is
+# committed in the repo, so no signing secret is needed.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create the GitHub Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Derive & verify version
+        id: ver
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          BASE="${VERSION%%-*}"   # strip any -rc/-beta suffix for the props comparison
+          PROPS="$(grep -oE '<VersionPrefix>[^<]+' build/version.props | sed 's/<VersionPrefix>//')"
+          echo "tag version: $VERSION (base $BASE) · version.props: $PROPS"
+          if [ "$BASE" != "$PROPS" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (base $BASE) does not match build/version.props VersionPrefix $PROPS. Bump version.props first."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then echo "prerelease=true" >> "$GITHUB_OUTPUT"; else echo "prerelease=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build protocol (codegen) first
+        run: dotnet build src/SkyApm.Transport.Protocol -c Release --no-restore
+
+      - name: Pack
+        run: |
+          dotnet pack skyapm-dotnet.sln -c Release --no-restore \
+            -p:Version=${{ steps.ver.outputs.version }} \
+            -p:ContinuousIntegrationBuild=true \
+            -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
+            -o artifacts
+
+      - name: Push packages to NuGet
+        run: |
+          dotnet nuget push "artifacts/*.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --skip-duplicate
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then PRERELEASE_FLAG="--prerelease"; fi
+          gh release create "${GITHUB_REF_NAME}" --generate-notes $PRERELEASE_FLAG artifacts/*.nupkg

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# Releasing SkyAPM-dotnet
+
+Status: **proposed automation** · Goal: pushing a `vX.Y.Z` tag **automatically** builds, packs,
+signs, publishes all NuGet packages to nuget.org, and creates a GitHub Release.
+
+The draft workflow that implements this is [`.github/workflows/release.yml`](.github/workflows/release.yml).
+It is inert until the `NUGET_API_KEY` secret is added (see [§4](#4-one-time-setup)).
+
+---
+
+## 1. Current state
+
+- **Packages:** ~30 packable libraries under `src/` (incl. the meta-packages `SkyAPM.Agent.AspNetCore`
+  / `SkyAPM.Agent.GeneralHost`) plus the `SkyApm.DotNet.CLI` global tool. Published to **nuget.org**.
+- **Version** comes from `build/version.props` (`VersionPrefix`, currently `2.3.0`).
+- **Signing** is strong-name via `build/SkyAPM.snk`, which is **committed** in the repo → no signing
+  secret is needed; the workflow only needs to build in `Release`.
+- **CI today** (`.github/workflows/net-ci-it.yml`) already triggers on `v*` tags but only
+  **builds/tests** — it never packs or pushes. Releasing is currently manual.
+- **The Cake script is stale** for releasing: `build/version.cake` detects tags only on
+  AppVeyor/Travis (not GitHub Actions), so a tag build under GHA would wrongly emit a
+  `-preview-<stamp>` suffix; it also globs a non-existent `./cli` path. → The release workflow uses
+  **plain `dotnet pack`**, not the Cake `Pack` task.
+
+## 2. How the automated release works
+
+`release.yml` triggers on **`push: tags: ['v*']`** and:
+
+1. **Checks out with submodules** (`recursive`) so the `protocol-v3` protobuf source is present.
+2. **Sets up .NET 8 + 10.**
+3. **Derives and verifies the version:** `VERSION=${GITHUB_REF_NAME#v}` and asserts that its base
+   (without any `-rc`/`-beta` suffix) equals `VersionPrefix` in `build/version.props`. A mismatch
+   **fails the job** — preventing a `v2.3.0` tag from publishing a differently-numbered package.
+4. **Builds the protocol project first**, then **packs the solution** in `Release`:
+   `dotnet pack -p:Version=$VERSION -p:ContinuousIntegrationBuild=true -p:SymbolPackageFormat=snupkg`
+   → `./artifacts`. (Samples are excluded via `sample/Directory.Build.props` → `IsPackable=false`;
+   test projects are already `IsPackable=false`.)
+5. **Pushes** `*.nupkg` + `*.snupkg` to nuget.org with `--skip-duplicate` (re-runs are safe).
+6. **Creates a GitHub Release** for the tag with auto-generated notes
+   (`gh release create --generate-notes`), marked **prerelease** when the tag has a `-suffix`.
+
+## 3. Cutting a release
+
+1. **Bump the version** in `build/version.props` (`VersionMajor`/`Minor`/`Patch`) on a PR and merge
+   it. (The consistency check in step 3 above turns a forgotten bump into a hard failure rather than
+   a mis-numbered publish.)
+2. **Tag and push:**
+   ```bash
+   git tag v2.3.0
+   git push origin v2.3.0
+   ```
+3. The **Release** workflow runs → packages on nuget.org + a GitHub Release appear.
+4. **Prereleases:** tag like `v2.4.0-rc1` → published as a NuGet prerelease and a GitHub
+   *pre-release*. (`version.props` may stay at `2.4.0`; only the base is compared.)
+
+## 4. One-time setup
+
+- **Add the `NUGET_API_KEY` secret** (repo → Settings → Secrets and variables → Actions, or at the
+  SkyAPM org level). Create the key on nuget.org scoped to **Glob `SkyApm.*` and `SkyAPM.*`** with
+  push + push-new-package rights.
+- That's the only required secret. The strong-name key is already in the repo.
+
+## 5. Decisions taken (no-ask defaults) & open questions
+
+**Defaults chosen:** publish target is **nuget.org only**; tag convention standardized on
+**`vX.Y.Z`** for both the code tag and the GitHub Release (older releases used a separate
+`vX.Y.Z-release` tag — dropped); symbols as **`.snupkg`**; the CLI global tool is published in the
+**same** release run and version; `net-ci-it.yml` keeps its `v*` trigger for build/test, while
+pack/push lives only in `release.yml`.
+
+**Open questions for review:** keep publishing prereleases to the myget `-vnext` feed on `main`
+pushes, or nuget.org only? `PackageRequireLicenseAcceptance=True` together with an SPDX
+`PackageLicenseExpression` triggers a nuget.org warning — consider dropping the former. Confirm the
+committed `SkyAPM.snk` is intentional identity-only signing (not to be rotated to a secret).

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!-- Import the repo-root props (TargetFrameworks, common.props, version, signing). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Sample apps are not published to NuGet. This keeps `dotnet pack` (release)
+         from emitting sample packages even though common.props sets
+         GeneratePackageOnBuild=True. -->
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+</Project>

--- a/test/plugin/PLAN.md
+++ b/test/plugin/PLAN.md
@@ -1,0 +1,199 @@
+# Plugin Test Plan (cross-version)
+
+Status: **proposed** · Scope: a plugin/integration test framework for SkyAPM-dotnet that verifies
+every instrumentation plugin against **multiple versions** of the library it instruments, and
+asserts the agent's **traces, metrics, logs, and (future) public APIs**.
+
+Modeled on the Apache SkyWalking **Java agent plugin-test** framework
+(`skywalking-java/test/plugin`) and reusing the existing, language-agnostic
+**`skywalking-agent-test-tool`** (mock OAP collector + YAML validator).
+
+---
+
+## 1. Goals
+
+1. **Catch regressions per plugin, per library version.** Each plugin (EF Core, MongoDB, CAP,
+   FreeSql, FreeRedis, MassTransit, SmartSql, SqlClient, gRPC, …) must keep producing correct
+   spans as the instrumented library evolves across its supported version range.
+2. **Cover all four telemetry paths**, including the planned additions:
+   - **Traces** — `SegmentReporter` → `TraceSegmentReportService`.
+   - **Metrics** — today `CLRStatsReporter` → `CLRMetricReportService`; **planned OTel-style
+     `Meter`** → `MeterReportService`.
+   - **Logs** — `LogReporter` → `LogReportService` (today fed only by MSLogging; **planned: more
+     log producers**).
+   - **Public APIs** — the **planned manual tracing/metric/log facade** (`ITracingContext` and a
+     public API surface).
+3. **Be runnable locally and in CI** with a clear, low-friction developer loop.
+
+## 2. How the Java framework works (reference)
+
+A Java *scenario* is a self-contained webapp (a JVM jar or a Tomcat war) plus three declarative
+files:
+
+| File | Purpose |
+|---|---|
+| `configuration.yml` | case metadata: `type` (jvm/tomcat), `entryService` (GET URL to drive traffic), `healthCheck` (HEAD URL), `startScript`, `runningMode`, and `dependencies` (side-car services → docker-compose) |
+| `support-version.list` | a **literal enumeration** of versions, one per line (`version[,key=value…]`). **No range DSL** — the runner loops each line |
+| `config/expectedData.yaml` | the expected segments/spans/refs with **operator-based** field assertions |
+
+`run.sh <scenario>` loops each version, rebuilds the same webapp with `-Dtest.framework.version=<v>`
+(injected as the library's dependency version), boots a Docker container with the agent + a
+**mock collector** mounted, waits on the health URL, sends one request to the entry URL, pulls the
+collected `actualData.yaml` from the mock collector's REST port, and runs the **validator** to
+compare actual vs expected. Container exit code = test result.
+
+**We adopt the same shape, idiomatically for .NET** — but split into two layers (below) because
+.NET's `DiagnosticSource` seam lets most assertions run **in-process**, far faster than
+container-per-version.
+
+## 3. Architecture — two layers
+
+### Layer 1 — In-process integration tests (the bulk; fast)
+
+One xUnit project per plugin: `test/plugin/integration/SkyApm.Diagnostics.<Plugin>.Tests`.
+
+- **Drive the real library against a real backend** spun up with **[Testcontainers for .NET]**
+  (Postgres, MySQL/MariaDB, MongoDB, Redis, RabbitMQ/Kafka, SQL Server). The library emits to its
+  real `DiagnosticListener`; `TracingDiagnosticProcessorObserver` dispatches to the plugin.
+- **Assert via capture-fakes.** Build the DI container with `AddSkyAPM(...)`, then **replace the
+  reporter/dispatcher interfaces** with in-memory capture implementations:
+  - `ISegmentDispatcher` / `ISegmentReporter` → captured **spans** (operationName, component,
+    layer, tags, peer, refs, error).
+  - `ILogReporter` → captured **logs** (+ trace correlation).
+  - `IMeterReporter` *(new, see §6)* / `ICLRStatsReporter` → captured **metrics**.
+
+  These are the single swap point — all live in `src/SkyApm.Abstractions/Transport/`.
+- **Why two styles per plugin:**
+  - *Handler-level* (fastest): call the `[DiagnosticName("…")]` methods directly with hand-built
+    `EventData` — no backend needed. Good for tag/edge-case coverage.
+  - *Library-level* (realistic): run the real library against the Testcontainers backend — proves
+    the listener name + event payloads still match the library version.
+
+### Layer 2 — End-to-end wire validation (smoke; reuses the SkyWalking tool)
+
+For a handful of representative scenarios per release, validate the **actual gRPC wire payload**
+end-to-end by reusing **`skywalking-agent-test-tool`** unchanged:
+
+- Run the mock collector as a container (see [`docker-compose.mock-collector.yml`](docker-compose.mock-collector.yml)):
+  `ghcr.io/apache/skywalking-agent-test-tool/mock-collector` — gRPC **:19876**, REST **:12800**.
+- Point the agent at it (`SkyWalking:Transport:gRPC:Servers = mock-collector:19876`), run a small
+  sample app, send one request, then `GET http://mock-collector:12800/receiveData` to dump
+  `actualData.yaml` and validate against an `expectedData.yaml`.
+- **Validator operators** (plain string = exact-equals): `null` · `not null` · `not blank` · `eq` ·
+  `nq` · `gt` · `ge` · `start with` · `end with`.
+- **Persistence caveat (important):** the mock collector **persists and returns only segments,
+  meters, and logs**. CLR/JVM-metrics, management (register/keepalive), and events are **ACKed but
+  not retrievable**. → Use Layer-1 in-process fakes to assert CLR metrics & management; use Layer 2
+  for traces, **Meter** metrics, and logs.
+
+## 4. Cross-version matrix
+
+- The library-under-test version is an **overridable MSBuild property**, e.g.
+  `<PackageReference Include="MongoDB.Driver" Version="$(LibVersion)" />` with a sensible default.
+- CI runs a matrix `dotnet test -p:LibVersion=<v>` over an explicit list per plugin — the .NET
+  equivalent of `support-version.list`. Keep one csproj per plugin and **float the version**, rather
+  than per-TFM `Condition` pinning.
+- Adopt **Central Package Management** (`Directory.Packages.props`) for the *shared/agent*
+  dependencies only (stop drift); keep each **library-under-test** version floated via the property.
+
+**Per-plugin version targets** (`support-version.list` equivalent — fill the concrete list per
+plugin; one representative version per minor, lowest-supported → latest):
+
+| Plugin | Library (NuGet) | Backend (Testcontainers) |
+|---|---|---|
+| EntityFrameworkCore | `Microsoft.EntityFrameworkCore` (+ `.Relational`) | per provider below |
+| …EntityFrameworkCore.Npgsql | `Npgsql.EntityFrameworkCore.PostgreSQL` | PostgreSQL |
+| …EntityFrameworkCore.Pomelo.MySql | `Pomelo.EntityFrameworkCore.MySql` | MySQL/MariaDB |
+| …EntityFrameworkCore.Sqlite | `Microsoft.EntityFrameworkCore.Sqlite` | (file/in-memory) |
+| MongoDB | `MongoDB.Driver` / `.Core` | MongoDB |
+| CAP | `DotNetCore.CAP` | RabbitMQ/Kafka + storage |
+| FreeSql | `FreeSql` | per provider |
+| FreeRedis | `FreeRedis` | Redis |
+| MassTransit | `MassTransit` | RabbitMQ |
+| SmartSql | `SmartSql` | SQLite/MySQL |
+| SqlClient | `System.Data.SqlClient` + `Microsoft.Data.SqlClient` | SQL Server |
+| Grpc / Grpc.Net.Client | `Grpc` / `Grpc.Net.Client` | in-process gRPC server |
+| HttpClient / AspNetCore / MSLogging | BCL (no external lib) | in-process |
+
+## 5. Directory layout
+
+```
+test/plugin/
+  PLAN.md                              ← this file
+  docker-compose.mock-collector.yml    ← Layer-2 mock collector (reused SkyWalking tool)
+  Directory.Packages.props             ← (to add) CPM for shared/agent deps
+  shared/
+    SkyApm.Testing.Harness/            ← capture-fakes + AddSkyAPM test host + assertion helpers
+  integration/
+    SkyApm.Diagnostics.EntityFrameworkCore.Tests/   ← support-versions.txt + Tests.cs
+    SkyApm.Diagnostics.MongoDB.Tests/
+    SkyApm.Diagnostics.Cap.Tests/
+    … (one per plugin)
+  e2e/
+    scenarios/
+      efcore-sqlite/{expectedData.yaml, app/, README.md}    ← Layer-2 scenarios
+```
+
+## 6. Covering the planned metrics / logs / public APIs
+
+The agent's reporters are interfaces in `src/SkyApm.Abstractions/Transport/`, each driven by an
+`ExecutionService` and bound in `ServiceCollectionExtensions`. The new features plug in cleanly and
+are testable with the same seams:
+
+- **Meter metrics** *(new)*: add `IMeterReporter` (mirror `ICLRStatsReporter`), a V8 `MeterReporter`
+  over the already-generated `MeterReportService` stub, and a `MeterStatsService` execution service
+  bridging `System.Diagnostics.Metrics`. **Tests:** capture-fake `IMeterReporter` (Layer 1) **and**
+  Layer-2 (meters *are* persisted by the mock collector → assertable end-to-end).
+- **More log collecting** *(new)*: new producers build a `LogRequest` and call
+  `ISkyApmLogDispatcher.Dispatch` (the existing `→ LogReporter` path is unchanged). **Tests:** fake
+  `ISkyApmLogDispatcher`, assert `LogData` fields + trace correlation; Layer-2 (logs persisted).
+- **Public APIs** *(new)*: the manual span/metric/log facade (around `ITracingContext`). **Tests:**
+  a dedicated `SkyApm.Api.Tests` contract suite — create spans/metrics/logs via the public API,
+  assert captured output and trace-context propagation. (Keep separate from per-plugin tests.)
+
+## 7. CI integration
+
+Add an **integration job** (the workflow is already named `net-ci-it` but has no IT job today) —
+either a new `plugin-it.yml` or a job in the existing CI:
+
+- Matrix: `{plugin} × {libVersion} × {tfm: net8.0}`. Keep unit tests on net8.0 + net10.0; run the
+  heavier container-backed IT on **net8.0** first (add net10.0 once its tooling stabilizes).
+- Steps: checkout `submodules: recursive` → setup .NET 8/10 → `dotnet restore -p:LibVersion=<v>` →
+  run the plugin's IT project (Testcontainers pulls backends) → (optional) Layer-2 scenario via the
+  mock-collector compose.
+- Mark the IT job **non-blocking/slower** initially; promote to required once stable. Pin any
+  third-party action to a reviewed commit SHA (ASF allow-list); `actions/*` are always allowed.
+
+## 8. Known hazards (from the code audit)
+
+- **MassTransit plugin csproj** references `SkyAPM.Agent.Hosting` / `.Diagnostics.AspNetCore` /
+  `.Utilities.DependencyInjection` as **published 2.0.0 NuGet packages**, not ProjectReferences.
+  Its test build must override these to ProjectReferences (a `Directory.Build.targets`) so the test
+  exercises *current* source.
+- **EF Core provider sub-plugins** (Npgsql/Pomelo/Sqlite) carry **no** library `PackageReference` —
+  they add peer formatters and rely on the consuming app to bring the provider; their tests must
+  supply the provider explicitly.
+- **net10.0 container tooling** is newer — start IT on net8.0 to reduce flakiness.
+
+## 9. Phased rollout
+
+1. **Harness** — `SkyApm.Testing.Harness` (capture-fakes + `AddSkyAPM` test host + span/log/meter
+   assertion helpers). Add `Directory.Packages.props`.
+2. **Pilot (2 plugins)** — EF Core (Sqlite, no backend) + MongoDB (Testcontainers) as the template;
+   wire the `-p:LibVersion=` matrix in CI.
+3. **Roll out** the remaining plugins one per PR, each with its `support-versions.txt`.
+4. **Layer 2** — add the mock-collector compose + 1–2 `expectedData.yaml` e2e scenarios (traces,
+   then meters + logs once those features land).
+5. **New features** — add Meter/log/API tests alongside the features as they ship.
+
+## 10. Decisions taken (no-ask defaults) & open questions
+
+**Defaults chosen:** in-process Layer-1 is primary; Layer-2 reuses the SkyWalking mock-collector
+unchanged (no .NET re-implementation); cross-version via MSBuild `-p:LibVersion` matrix +
+Testcontainers; IT on net8.0 first.
+
+**Open questions for review:** exact version list per plugin (lowest-supported → latest); whether
+the new public APIs extend `ITracingContext` or a separate facade; whether `Transport.Kafka` gets
+its own e2e leg; and whether to keep the myget `-vnext` prerelease feed.
+
+[Testcontainers for .NET]: https://dotnet.testcontainers.org/

--- a/test/plugin/docker-compose.mock-collector.yml
+++ b/test/plugin/docker-compose.mock-collector.yml
@@ -1,0 +1,29 @@
+# Layer-2 (end-to-end) mock OAP collector for plugin tests.
+#
+# Reuses the Apache SkyWalking agent-test-tool UNCHANGED — it speaks the same
+# sw8/v8 gRPC protocol the .NET agent already uses. Point the agent at it:
+#   SkyWalking:Transport:gRPC:Servers = localhost:19876
+#
+# Then drive your sample app, and read the collected data back over REST:
+#   GET    http://localhost:12800/receiveData   -> dumps actualData.yaml
+#   DELETE http://localhost:12800/receiveData   -> clears captured data
+#   HEAD   http://localhost:12800/healthCheck    -> readiness
+#
+# NOTE: the mock collector persists/returns only SEGMENTS, METERS, and LOGS.
+# CLR metrics, management (register/keepalive), and events are ACKed but NOT
+# retrievable — assert those with in-process capture-fakes (Layer 1) instead.
+#
+# Usage:  docker compose -f test/plugin/docker-compose.mock-collector.yml up -d
+
+services:
+  mock-collector:
+    image: ghcr.io/apache/skywalking-agent-test-tool/mock-collector:latest
+    container_name: skyapm-mock-collector
+    ports:
+      - "19876:19876"   # gRPC receiver (point the agent here)
+      - "12800:12800"   # REST: receiveData / clearData / healthCheck / dataValidate
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:12800/healthCheck || exit 1"]
+      interval: 5s
+      timeout: 10s
+      retries: 30

--- a/test/plugin/e2e/scenarios/example-http/expectedData.yaml
+++ b/test/plugin/e2e/scenarios/example-http/expectedData.yaml
@@ -1,0 +1,43 @@
+# Example Layer-2 expectedData.yaml — the format the SkyWalking validator asserts
+# against the actualData.yaml dumped from the mock collector's REST API.
+#
+# Operators (a bare value means exact-equals): null | not null | not blank | eq |
+# nq | gt | ge | start with | end with. Use them as `key: <operator> <value>`.
+#
+# This example expects ONE inbound ASP.NET Core request span (entry) plus one
+# outbound HttpClient span (exit) in a single segment.
+
+segmentItems:
+  - serviceName: example-http-service
+    segmentSize: ge 1
+    segments:
+      - segmentId: not null
+        spans:
+          - operationName: GET:/api/values          # entry span (ASP.NET Core)
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 6004                        # AspNetCore component id
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - { key: http.method, value: GET }
+              - { key: url, value: not blank }
+              - { key: status_code, value: '200' }
+          - operationName: not blank                 # exit span (HttpClient)
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Http
+            componentId: 6005                         # HttpClient component id
+            isError: false
+            spanType: Exit
+            peer: not blank
+            tags:
+              - { key: http.method, value: GET }
+              - { key: url, value: not blank }
+            refs: []


### PR DESCRIPTION
Two planning deliverables (with starter scaffolding), researched against the SkyWalking Java agent's plugin-test framework and `skywalking-agent-test-tool`, and the repo's current build/release setup.

## 1. Plugin cross-version testing — [`test/plugin/PLAN.md`](test/plugin/PLAN.md)

Verify every instrumentation plugin against **multiple versions** of the library it instruments, covering **traces, metrics, logs, and the planned public APIs**.

- **Two layers:** (1) fast **in-process** integration tests per plugin — drive the *real* library via **Testcontainers** and assert via **capture-fakes** on the reporter/dispatcher seams (`ISegmentDispatcher` / `ILogReporter` / new `IMeterReporter`); (2) **end-to-end wire validation** that reuses the **`skywalking-agent-test-tool` mock collector + validator unchanged** (same sw8/v8 gRPC).
- **Cross-version** via an MSBuild `-p:LibVersion=` matrix (the `support-version.list` equivalent) + per-plugin version lists.
- **Telemetry coverage** incl. the planned **Meter metrics**, **more log collecting**, and **public APIs** — with the seam where each plugs in. Caveat documented: the mock collector persists **segments/meters/logs** only; CLR-metrics/management/events need in-process fakes.
- Scaffolding: [`docker-compose.mock-collector.yml`](test/plugin/docker-compose.mock-collector.yml) + an example [`expectedData.yaml`](test/plugin/e2e/scenarios/example-http/expectedData.yaml).

## 2. Automated NuGet release on tag — [`RELEASING.md`](RELEASING.md) + [`.github/workflows/release.yml`](.github/workflows/release.yml)

Push a `vX.Y.Z` tag → build → pack → publish to nuget.org → GitHub Release, automatically.

- Verifies the tag matches `build/version.props` (fails on mismatch), builds the protocol first, `dotnet pack` (not the **stale Cake** path, whose tag detection is AppVeyor-only), pushes `*.nupkg`/`*.snupkg` with `--skip-duplicate`, and `gh release create --generate-notes` (prerelease-aware).
- Strong-name key is already committed → **only new requirement is a `NUGET_API_KEY` secret**.
- [`sample/Directory.Build.props`](sample/Directory.Build.props) marks sample apps `IsPackable=false` so the release pack emits only the real libraries (verified locally).

Both are **plans for review** — the release workflow is a working draft (inert until the secret is added). Open questions and no-ask defaults are listed at the bottom of each doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)