### PR TITLE
e2e: trace/log/metric verification for .NET 8 & 10 (+ CLAUDE.md, footer fix)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Keep the e2e demo build context small (src + protocol-v3 submodule + build props).
+**/bin/
+**/obj/
+artifacts/
+public/
+resources/
+.git/
+themes/
+content/
+i18n/
+node_modules/
+*.log
+test/e2e/**/app*.log
+test/e2e/**/actualData.yaml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,47 @@
+name: E2E
+
+# Builds the .NET 8 / .NET 10 demo services (agent from source), boots a pinned
+# SkyWalking OAP + BanyanDB, and verifies trace/log/metric reached OAP.
+# Heavy (~10-15 min), so it only runs when the agent or the e2e changes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'test/e2e/**'
+      - '.dockerignore'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/e2e/**'
+      - '.dockerignore'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive   # protocol-v3 is needed to build the agent in the demo image
+          fetch-depth: 0
+
+      - name: Run end-to-end test (OAP + BanyanDB + net8/net10 demos)
+        env:
+          SKIP_CLEANUP: "1"       # let the steps below collect logs / tear down
+        run: bash test/e2e/run.sh
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f test/e2e/docker-compose.yml logs --tail=200 || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f test/e2e/docker-compose.yml down -v || true

--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,8 @@ generated-v3/
 /public/
 /resources/_gen/
 .hugo_build.lock
+
+# e2e demo runtime artifacts
+test/e2e/**/logs/
+test/e2e/**/app*.log
+test/e2e/**/actualData.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# SkyAPM-dotnet — repository guide
+
+C#/.NET auto-instrumentation agent for the .NET ecosystem that reports tracing, metrics, and logs
+to an Apache SkyWalking backend over the **sw8 / v8** gRPC protocol. Targets **net8.0** and
+**net10.0**; foundational libraries also build for **netstandard2.0**. Version in `build/version.props`.
+
+## Layout
+
+```
+src/                         The agent (≈30 NuGet packages)
+  SkyApm.Abstractions/         interfaces + Config classes (telemetry contracts)
+  SkyApm.Core/                 tracing engine, sampling, context
+  SkyApm.Agent.AspNetCore/     ASP.NET Core host (zero-code via HostingStartup); assembly = SkyAPM.Agent.AspNetCore
+  SkyApm.Agent.GeneralHost/    generic-host (console/Worker) entry
+  SkyApm.Agent.Hosting/        shared composition root (AddSkyAPM); wires default plugins + transport
+  SkyApm.Diagnostics.*/         16 plugins (AspNetCore, HttpClient, SqlClient, EntityFrameworkCore[+providers],
+                               Grpc, Grpc.Net.Client, MSLogging, CAP, MassTransit, MongoDB, SmartSql,
+                               FreeSql, FreeRedis) — thin DiagnosticSource adapters
+  SkyApm.Transport.Grpc/        default reporter: Segment(traces)/CLRStats(metrics)/Log/Register/Ping (V8/)
+  SkyApm.Transport.Kafka/       alternative Kafka reporter
+  SkyApm.Transport.Protocol/    gRPC stubs codegen'd from the protocol-v3 git submodule
+  SkyApm.PeerFormatters.*/      DB peer-address resolvers
+  SkyApm.DotNet.CLI/            `dotnet skyapm config` global tool
+test/
+  SkyApm.Core.Tests/            xUnit unit tests (the only existing tests)
+  e2e/                          end-to-end demo + setup (in progress)
+sample/                        runnable example apps (Frontend→Backend, FreeSql, GenericHost, grpc, …)
+build/                         common/version/sign .props, version.cake, SkyAPM.snk (strong-name key)
+content/                       Hugo (Hextra theme) documentation site → GitHub Pages
+themes/hugo-... , hugo.toml, i18n/   docs site theme + config (.github/workflows/docs.yml deploys)
+.github/workflows/            net-ci-it.yml (build+test net8/net10), docs.yml (Pages)
+```
+
+## Build / test
+
+- `git submodule update --init` (populates `src/SkyApm.Transport.Protocol/protocol-v3`).
+- `dotnet restore` → `dotnet build src/SkyApm.Transport.Protocol` (codegen first) → `dotnet build`.
+- `dotnet test --framework net8.0` (and `net10.0`). Only the net8/net10 *runtimes* are tested.
+
+## Conventions / gotchas
+
+- Activation: env `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=SkyAPM.Agent.AspNetCore` (note casing `APM`).
+- Config: `skyapm.json` (or env `SKYWALKING__...`, double-underscore). Agent no-ops if `ServiceName`
+  empty or `SkyWalking:Enable=false`. Full reference: `content/docs/guides/skyapm_config.md`.
+- Plugins: a fixed default set is auto-registered; others are opt-in via the `AddSkyAPM(ext => …)` lambda.
+- The repo also pins per-TFM package versions via `Condition="'$(TargetFramework)' == 'netX'"` blocks.
+- Project is **independent** — reports to Apache SkyWalking but is not an ASF/SkyWalking sub-project.

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -48,6 +48,10 @@ This agent speaks the SkyWalking **v8** protocol and propagates context with the
 
 - [How to Build](guides/how-to-build.md) — compile the agent from source, including the Git submodule and protocol-build steps.
 
+### End-to-End Testing
+
+- [End-to-End Testing](guides/e2e.md) — the containerized e2e (OAP + BanyanDB + .NET 8/10 demos) that verifies trace, log, and metric reporting.
+
 ## Quick Reference
 
 | Topic | Default | Notes |

--- a/content/docs/guides/e2e.md
+++ b/content/docs/guides/e2e.md
@@ -1,0 +1,58 @@
+---
+title: "End-to-End Testing"
+weight: 11
+---
+
+The repository ships a containerized end-to-end test under [`test/e2e/`](https://github.com/SkyAPM/SkyAPM-dotnet/tree/main/test/e2e)
+that proves the agent reports **traces, logs, and CLR metrics** to a real, version-pinned Apache
+SkyWalking **OAP + BanyanDB** backend — for demo services running on **.NET 8 and .NET 10**.
+
+## Run it
+
+```bash
+bash test/e2e/run.sh
+```
+
+This builds the demo images, boots the stack via Docker Compose, drives traffic, verifies the data
+in OAP, and tears everything down. Requires **docker** and **python3**. You can also run it through
+the [skywalking-infra-e2e](https://github.com/apache/skywalking-infra-e2e) framework:
+
+```bash
+e2e run -c test/e2e/e2e.yaml
+```
+
+## What it asserts (per service, ×2 TFMs)
+
+| Telemetry | How it's produced | How it's verified |
+| --- | --- | --- |
+| **trace** | inbound `GET /work` + an outbound HttpClient call to `/downstream` | OAP `service_cpm` has a value |
+| **log** | `ILogger` records via the MSLogging plugin | OAP `queryLogs` returns records |
+| **metric** | CLR runtime metrics | OAP `instance_clr_available_worker_threads` has a value |
+
+Verification uses the OAP **GraphQL API** directly (`verify.py`), so it is not coupled to a specific
+`swctl` version.
+
+## Layout
+
+| File | Purpose |
+| --- | --- |
+| `demo/` | minimal ASP.NET Core app + multi-stage `Dockerfile` (net8/net10); references the agent **from source**, activated via `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=SkyAPM.Agent.AspNetCore` |
+| `docker-compose.yml` | pinned OAP + BanyanDB + `demo-net8` + `demo-net10`, all on one network |
+| `verify.py` | GraphQL verifier (services / traces / logs / CLR metrics) |
+| `run.sh` | self-contained runner | 
+| `e2e.yaml` + `expected/` | skywalking-infra-e2e config |
+
+Pin a different backend with env: `OAP_IMAGE=...`, `BANYANDB_IMAGE=...`.
+
+## CI
+
+The `.github/workflows/e2e.yml` workflow runs this on changes to `src/**` or `test/e2e/**` (and on
+manual dispatch), building the net8/net10 images and asserting trace/log/metric.
+
+## Networking note (cleartext gRPC / h2c)
+
+The agent reports to OAP's **plaintext gRPC (`oap:11800`) over the Docker network**, not a host
+port. .NET cleartext HTTP/2 (h2c) does **not** reliably survive Docker Desktop's macOS host
+port-forward — a host-run agent against a forwarded OAP port can fail with
+`unable to establish HTTP/2 connection` ([#571](https://github.com/SkyAPM/SkyAPM-dotnet/issues/571)).
+Keeping the agent and OAP on the same Docker network (as this compose does) avoids it.

--- a/hugo.toml
+++ b/hugo.toml
@@ -45,6 +45,7 @@ enableRobotsTXT = true
   [params.footer]
     enable = true
     displayCopyright = true
+    displayPoweredBy = false
 
   [params.editURL]
     enable = true

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,2 @@
+# Overrides the Hextra theme's default footer copyright string.
+copyright: "© SkyAPM. Licensed under the Apache License 2.0."

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,40 @@
+# End-to-end test
+
+Verifies that the SkyAPM .NET agent reports **traces, logs, and CLR metrics** to a real,
+**version-pinned** Apache SkyWalking **OAP + BanyanDB** backend, for demo services running on
+**.NET 8 and .NET 10**.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `demo/` | Minimal ASP.NET Core app + `Dockerfile` (multi-target net8/net10); references the agent **from source** and is activated via `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=SkyAPM.Agent.AspNetCore` |
+| `docker-compose.yml` | Pinned `apache/skywalking-oap-server` + `apache/skywalking-banyandb` + `demo-net8` + `demo-net10`, all on one network |
+| `run.sh` | Self-contained runner: build+up → traffic → assert trace/log/metric per service via `swctl` |
+| `e2e.yaml` + `expected/` | [skywalking-infra-e2e](https://github.com/apache/skywalking-infra-e2e) config for CI (`e2e run -c test/e2e/e2e.yaml`) |
+
+## Run it
+
+```bash
+bash test/e2e/run.sh            # builds images, boots the stack, verifies, tears down
+# or, via the infra-e2e framework:
+e2e run -c test/e2e/e2e.yaml
+```
+
+Pin a different SkyWalking/BanyanDB via env: `OAP_IMAGE=apache/skywalking-oap-server:<tag>`,
+`BANYANDB_IMAGE=apache/skywalking-banyandb:<tag>`.
+
+## What it asserts (per service, ×2 TFMs)
+
+- **trace** — OAP learned the endpoint `GET:/work` (entry span) — the demo also makes an
+  HttpClient call to `/downstream` (exit span + a second segment).
+- **log** — application logs (via the MSLogging plugin) reached OAP.
+- **metric** — a CLR instance metric (`instance_clr_available_worker_threads`) has values.
+
+## Important: networking
+
+The demos talk to OAP's **plaintext gRPC (`oap:11800`) over the Docker network**, not via a host
+port. .NET cleartext HTTP/2 (h2c) does **not** survive Docker Desktop's macOS host port-forward
+(you'll see `unable to establish HTTP/2 connection` / issue #571) — so the agent and OAP must share
+a Docker network, which this compose does. Only OAP's HTTP query port `12800` is exposed to the
+host (for `swctl`).

--- a/test/e2e/demo/Demo.csproj
+++ b/test/e2e/demo/Demo.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SkyApm.E2E.Demo</RootNamespace>
+    <!-- demo app, never published -->
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- reference the agent SOURCE so the e2e exercises current code -->
+    <ProjectReference Include="../../../src/SkyApm.Agent.AspNetCore/SkyApm.Agent.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Enable cleartext HTTP/2 (h2c) at process start so the agent can report to
+         OAP's plaintext gRPC. Set via runtimeconfig (not AppContext) because the
+         switch is read once at SocketsHttpHandler type-init. -->
+    <RuntimeHostConfigurationOption Include="System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport" Value="true" Trim="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="skyapm.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/test/e2e/demo/Dockerfile
+++ b/test/e2e/demo/Dockerfile
@@ -9,6 +9,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG TFM=net8.0
 WORKDIR /src
 COPY . .
+# Build the protocol project FIRST so the gRPC/protobuf code is generated from the
+# protocol-v3 submodule before the transports compile (mirrors the repo CI). A
+# clean checkout has no generated-v3/ (it is gitignored), so without this the
+# Transport.Kafka build fails with missing SegmentObject/SpanObject types.
+RUN dotnet build src/SkyApm.Transport.Protocol -c Release
 RUN dotnet publish test/e2e/demo/Demo.csproj -c Release -f ${TFM} -o /app
 
 FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS run

--- a/test/e2e/demo/Dockerfile
+++ b/test/e2e/demo/Dockerfile
@@ -1,0 +1,22 @@
+# Multi-stage build for the e2e demo. Build context MUST be the repo root so the
+# agent source + the protocol-v3 submodule are available:
+#   docker build -f test/e2e/demo/Dockerfile --build-arg DOTNET_VERSION=8.0 --build-arg TFM=net8.0 -t skyapm-e2e-demo:net8 .
+ARG DOTNET_VERSION=8.0
+
+# Always build with the .NET 10 SDK — it can target both net8.0 and net10.0
+# (the agent's shared libs multi-target net8.0;net10.0;netstandard2.0).
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TFM=net8.0
+WORKDIR /src
+COPY . .
+RUN dotnet publish test/e2e/demo/Demo.csproj -c Release -f ${TFM} -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION} AS run
+WORKDIR /app
+COPY --from=build /app .
+# Activate the agent (note casing: SkyAPM). Service name + OAP address come from env.
+ENV ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=SkyAPM.Agent.AspNetCore \
+    ASPNETCORE_URLS=http://+:8080 \
+    DEMO_SELF_URL=http://localhost:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "Demo.dll"]

--- a/test/e2e/demo/Program.cs
+++ b/test/e2e/demo/Program.cs
@@ -1,0 +1,31 @@
+// Minimal ASP.NET Core demo app for the SkyAPM-dotnet end-to-end test.
+// The agent is attached purely via the ASPNETCORE_HOSTINGSTARTUPASSEMBLIES env var
+// (no code wiring). GET /work makes an outbound HttpClient call to /downstream so
+// the trace contains an inbound (AspNetCore) entry span + an HttpClient exit span
+// + a second segment for the downstream entry — and writes an application log.
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddHttpClient();
+var app = builder.Build();
+
+// Address this app uses to call itself (the HttpClient exit span). Defaults to the
+// in-container listen address; override with DEMO_SELF_URL for host runs.
+var self = builder.Configuration["DEMO_SELF_URL"] ?? "http://localhost:8080";
+
+app.MapGet("/healthz", () => "ok");
+
+app.MapGet("/downstream", (ILogger<Program> log) =>
+{
+    log.LogInformation("downstream hit");
+    return "downstream ok";
+});
+
+app.MapGet("/work", async (IHttpClientFactory factory, ILogger<Program> log) =>
+{
+    log.LogInformation("work: calling downstream");
+    var client = factory.CreateClient();
+    var downstream = await client.GetStringAsync($"{self}/downstream");
+    return Results.Ok(new { work = "done", downstream });
+});
+
+app.Run();

--- a/test/e2e/demo/skyapm.json
+++ b/test/e2e/demo/skyapm.json
@@ -1,0 +1,10 @@
+{
+  "SkyWalking": {
+    "ServiceName": "e2e-demo",
+    "Transport": {
+      "gRPC": {
+        "Servers": "localhost:19876"
+      }
+    }
+  }
+}

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -1,0 +1,72 @@
+# End-to-end stack: a PINNED Apache SkyWalking OAP + BanyanDB storage, plus the
+# .NET 8 and .NET 10 demo services (agent built from source). Everything runs on
+# one Docker network so the agent reaches OAP's plaintext gRPC (h2c) directly —
+# do NOT rely on host port-forwarding for the agent->OAP gRPC (Docker Desktop on
+# macOS mangles cleartext HTTP/2 over the host forward).
+#
+#   docker compose -f test/e2e/docker-compose.yml up -d --build
+#
+# Pin the SkyWalking/BanyanDB versions here (override via env if needed).
+
+services:
+  banyandb:
+    image: ${BANYANDB_IMAGE:-ghcr.io/apache/skywalking-banyandb:7ae98e0b6addfe216b32712c57c054eabee5a4c2}
+    command: ["standalone"]
+    networks: [e2e]
+    expose: ["17912"]
+    healthcheck:
+      test: ["CMD", "sh", "-c", "nc -nz 127.0.0.1 17912"]
+      interval: 5s
+      timeout: 60s
+      retries: 60
+
+  oap:
+    image: ${OAP_IMAGE:-ghcr.io/apache/skywalking/oap:bb16533009a597dbb41ab6f013ac300509abbb3e}
+    depends_on:
+      banyandb:
+        condition: service_healthy
+    networks: [e2e]
+    ports:
+      - "12800:12800"   # query/GraphQL (swctl verifies here over HTTP — host-forward is fine for HTTP/1.1)
+    environment:
+      SW_STORAGE: banyandb
+      SW_STORAGE_BANYANDB_TARGETS: banyandb:17912
+      SW_HEALTH_CHECKER: default
+      JAVA_OPTS: "-Xms512m -Xmx512m"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/12800"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 90s
+
+  demo-net8:
+    build:
+      context: ../..
+      dockerfile: test/e2e/demo/Dockerfile
+      args: { DOTNET_VERSION: "8.0", TFM: "net8.0" }
+    depends_on:
+      oap:
+        condition: service_healthy
+    networks: [e2e]
+    ports: ["18801:8080"]
+    environment:
+      SKYWALKING__SERVICENAME: e2e-demo-net8
+      SKYWALKING__TRANSPORT__GRPC__SERVERS: oap:11800
+
+  demo-net10:
+    build:
+      context: ../..
+      dockerfile: test/e2e/demo/Dockerfile
+      args: { DOTNET_VERSION: "10.0", TFM: "net10.0" }
+    depends_on:
+      oap:
+        condition: service_healthy
+    networks: [e2e]
+    ports: ["18802:8080"]
+    environment:
+      SKYWALKING__SERVICENAME: e2e-demo-net10
+      SKYWALKING__TRANSPORT__GRPC__SERVERS: oap:11800
+
+networks:
+  e2e: {}

--- a/test/e2e/e2e.yaml
+++ b/test/e2e/e2e.yaml
@@ -1,0 +1,36 @@
+# Apache skywalking-infra-e2e configuration. Run with the `e2e` CLI:
+#   e2e run -c test/e2e/e2e.yaml
+# (or via the apache/skywalking-infra-e2e GitHub Action in CI.)
+#
+# Boots the pinned OAP + BanyanDB + the .NET 8 / .NET 10 demos (docker-compose.yml),
+# drives traffic, then verifies the services/traces are present in OAP via swctl.
+# swctl must be on PATH and pointed at http://localhost:12800.
+
+setup:
+  env: compose
+  file: docker-compose.yml
+  timeout: 25m
+  init-system-environment: ../../skywalking-infra-e2e/script/env  # optional; ignore if absent
+  steps:
+    - name: generate traffic on both demos
+      command: |
+        for i in $(seq 1 15); do
+          curl -sf http://localhost:18801/work >/dev/null || true
+          curl -sf http://localhost:18802/work >/dev/null || true
+          sleep 1
+        done
+        # allow OAP/BanyanDB to index traces, logs and metrics
+        sleep 45
+
+cleanup:
+  on: always
+
+verify:
+  retry:
+    count: 20
+    interval: 10s
+  cases:
+    # Asserts trace + log + CLR metric reached OAP for both demo services, via
+    # the OAP GraphQL API (version-robust). stdout is `result: PASSED` on success.
+    - query: python3 verify.py
+      expected: expected/result.yml

--- a/test/e2e/expected/result.yml
+++ b/test/e2e/expected/result.yml
@@ -1,0 +1,1 @@
+result: PASSED

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# End-to-end test: boots a pinned SkyWalking OAP + BanyanDB and the .NET 8 / .NET 10
+# demo services (agent from source), generates traffic, and verifies TRACES, LOGS
+# and CLR METRICS for BOTH services reached OAP — via GraphQL (version-robust; no
+# swctl version coupling). Requires docker + python3.
+#
+#   bash test/e2e/run.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+COMPOSE="docker compose -f docker-compose.yml"
+OAP_GRAPHQL="http://localhost:12800/graphql"
+
+cleanup() { $COMPOSE down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "==> (1/4) build + start stack (OAP + BanyanDB + demo-net8 + demo-net10)"
+$COMPOSE up -d --build
+echo "    waiting for OAP (:12800) and demos…"
+for _ in $(seq 1 60); do curl -sf http://localhost:12800/internal/l7check >/dev/null 2>&1 && break; sleep 3; done
+for _ in $(seq 1 40); do curl -sf localhost:18801/healthz >/dev/null 2>&1 && curl -sf localhost:18802/healthz >/dev/null 2>&1 && break; sleep 2; done
+
+echo "==> (2/4) generate traffic on both demos"
+for _ in $(seq 1 25); do
+  curl -sf http://localhost:18801/work >/dev/null || true   # net8
+  curl -sf http://localhost:18802/work >/dev/null || true   # net10
+  sleep 0.5
+done
+
+echo "==> (3/4) wait for OAP/BanyanDB to index (traces, logs, metrics)…"
+sleep 55
+
+echo "==> (4/4) verify trace / log / metric via GraphQL"
+python3 verify.py "$OAP_GRAPHQL" e2e-demo-net8 e2e-demo-net10

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -11,7 +11,8 @@ cd "$(dirname "$0")"
 COMPOSE="docker compose -f docker-compose.yml"
 OAP_GRAPHQL="http://localhost:12800/graphql"
 
-cleanup() { $COMPOSE down -v >/dev/null 2>&1 || true; }
+# Set SKIP_CLEANUP=1 (e.g. in CI) to leave the stack up so logs can be collected.
+cleanup() { [ -n "${SKIP_CLEANUP:-}" ] && return 0; $COMPOSE down -v >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
 echo "==> (1/4) build + start stack (OAP + BanyanDB + demo-net8 + demo-net10)"

--- a/test/e2e/verify.py
+++ b/test/e2e/verify.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Version-robust e2e verifier: queries the SkyWalking OAP GraphQL API directly
+(no swctl version coupling) to assert TRACES, LOGS, and CLR METRICS reached OAP
+for each demo service.
+
+Diagnostics go to stderr; stdout prints `result: PASSED` (and exit 0) or
+`result: FAILED` (exit 1) so it works both standalone and as a
+skywalking-infra-e2e verify case.
+
+Usage: python3 verify.py [oap_graphql_url] svc1 svc2 ...
+"""
+import sys, json, datetime, urllib.request
+
+URL = "http://localhost:12800/graphql"
+args = sys.argv[1:]
+if args and args[0].startswith("http"):
+    URL = args.pop(0)
+SERVICES = args or ["e2e-demo-net8", "e2e-demo-net10"]
+
+
+def log(*a):
+    print(*a, file=sys.stderr)
+
+
+def gql(query, variables):
+    body = json.dumps({"query": query, "variables": variables}).encode()
+    req = urllib.request.Request(URL, body, {"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        out = json.load(r)
+    if out.get("errors"):
+        raise RuntimeError(out["errors"])
+    return out["data"]
+
+
+def duration(minutes=30):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    fmt = lambda t: t.strftime("%Y-%m-%d %H%M")
+    return {"start": fmt(now - datetime.timedelta(minutes=minutes)), "end": fmt(now), "step": "MINUTE"}
+
+
+def services():
+    d = gql("query($d:Duration!){getAllServices(duration:$d){id name}}", {"d": duration()})
+    return {s["name"]: s["id"] for s in d["getAllServices"]}
+
+
+def instance(service_id):
+    d = gql("query($d:Duration!,$s:ID!){getServiceInstances(duration:$d,serviceId:$s){id name}}",
+            {"d": duration(), "s": service_id})
+    return d["getServiceInstances"][0] if d["getServiceInstances"] else None
+
+
+def metric_has_value(name, entity):
+    d = gql("query($c:MetricsCondition!,$d:Duration!){readMetricsValues(condition:$c,duration:$d){values{values{value isEmptyValue}}}}",
+            {"c": {"name": name, "entity": entity}, "d": duration()})
+    return any(not v["isEmptyValue"] for v in d["readMetricsValues"]["values"]["values"])
+
+
+def has_logs(service_id):
+    d = gql("query($c:LogQueryCondition){queryLogs(condition:$c){logs{content}}}",
+            {"c": {"serviceId": service_id, "queryDuration": duration(), "paging": {"pageNum": 1, "pageSize": 5}}})
+    return len(d["queryLogs"]["logs"]) > 0
+
+
+def main():
+    failures = []
+    svcs = services()
+    log(f"services in OAP: {list(svcs)}")
+    for name in SERVICES:
+        log(f"--- {name} ---")
+        sid = svcs.get(name)
+        if not sid:
+            failures.append(f"{name}: not registered"); log("  FAIL: not registered"); continue
+        try:
+            ok = metric_has_value("service_cpm", {"scope": "Service", "serviceName": name, "normal": True})
+            log(f"  trace  {'OK' if ok else 'FAIL'} (service_cpm)"); ok or failures.append(f"{name}: no trace cpm")
+        except Exception as e:
+            failures.append(f"{name}: trace query error {e}"); log(f"  FAIL trace: {e}")
+        try:
+            ok = has_logs(sid); log(f"  log    {'OK' if ok else 'FAIL'}"); ok or failures.append(f"{name}: no logs")
+        except Exception as e:
+            failures.append(f"{name}: log query error {e}"); log(f"  FAIL log: {e}")
+        inst = instance(sid)
+        if not inst:
+            failures.append(f"{name}: no instance"); log("  FAIL: no instance"); continue
+        try:
+            ok = metric_has_value("instance_clr_available_worker_threads",
+                                  {"scope": "ServiceInstance", "serviceName": name, "serviceInstanceName": inst["name"], "normal": True})
+            log(f"  metric {'OK' if ok else 'FAIL'} (instance_clr_available_worker_threads)"); ok or failures.append(f"{name}: no CLR metric")
+        except Exception as e:
+            failures.append(f"{name}: metric query error {e}"); log(f"  FAIL metric: {e}")
+    if failures:
+        log("\nFAILURES:\n  " + "\n  ".join(failures))
+        print("result: FAILED")
+        sys.exit(1)
+    log("\ntrace + log + metric verified for: " + ", ".join(SERVICES))
+    print("result: PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## End-to-end test (`test/e2e/`)

A containerized e2e that proves the agent reports **traces, logs, and CLR metrics** to a real, **version-pinned** SkyWalking **OAP + BanyanDB**, for demo services on **.NET 8 and .NET 10**.

- **Verified green** against the dev images `oap:bb16533009` + `banyandb:7ae98e0b`:
  ```
  e2e-demo-net8 :  trace OK · log OK · metric OK
  e2e-demo-net10:  trace OK · log OK · metric OK
  [PASSED]
  ```
- `demo/` — minimal ASP.NET Core app + multi-stage `Dockerfile` (net8/net10), agent built **from source**, activated purely via the `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES` env var.
- `docker-compose.yml` — pinned OAP + BanyanDB + both demos on one network. **Run:** `bash test/e2e/run.sh` (or `e2e run -c test/e2e/e2e.yaml`).
- `verify.py` — version-robust GraphQL verifier (no swctl↔OAP version coupling).

### Note on #571 (gRPC h2c)
A host-run agent against a Docker-Desktop-exposed OAP fails with `unable to establish HTTP/2 connection` — this is **Docker Desktop (macOS) mangling cleartext HTTP/2** over the host port-forward, **not an agent bug**. On a shared Docker network (as this e2e uses) the agent reports cleanly. The README documents this.

## Also included
- **`CLAUDE.md`** — concise repo-structure guide.
- **Docs footer** — now `© SkyAPM ...` (dropped "Powered by Hextra"), per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)