### PR TITLE
ci: one-click release workflow (bump → tag → NuGet publish → next-version PR)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,11 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           BASE="${VERSION%%-*}"   # strip any -rc/-beta suffix for the props comparison
           # VersionPrefix is "$(VersionMajor).$(VersionMinor).$(VersionPatch)" — resolve from the parts.
-          MAJOR="$(grep -oE '<VersionMajor>[0-9]+' build/version.props | grep -oE '[0-9]+')"
-          MINOR="$(grep -oE '<VersionMinor>[0-9]+' build/version.props | grep -oE '[0-9]+')"
-          PATCH="$(grep -oE '<VersionPatch>[0-9]+' build/version.props | grep -oE '[0-9]+')"
+          read_part() { grep -oE "<$1>[0-9]+</$1>" build/version.props | grep -oE '[0-9]+' | head -1 || true; }
+          MAJOR="$(read_part VersionMajor)"; MINOR="$(read_part VersionMinor)"; PATCH="$(read_part VersionPatch)"
+          for p in MAJOR MINOR PATCH; do
+            [ -n "${!p}" ] || { echo "::error::could not read Version$p from build/version.props"; exit 1; }
+          done
           PROPS="${MAJOR}.${MINOR}.${PATCH}"
           echo "tag version: $VERSION (base $BASE) · version.props: $PROPS"
           if [ "$BASE" != "$PROPS" ]; then
@@ -53,7 +55,9 @@ jobs:
         run: dotnet restore
 
       - name: Build protocol (codegen) first
-        run: dotnet build src/SkyApm.Transport.Protocol -c Release --no-restore
+        # -p:GeneratePackageOnBuild=false avoids a stray, mis-versioned protocol nupkg
+        # (the global default packs on build); the real package is produced by Pack below.
+        run: dotnet build src/SkyApm.Transport.Protocol -c Release --no-restore -p:GeneratePackageOnBuild=false
 
       - name: Pack
         run: |
@@ -62,6 +66,18 @@ jobs:
             -p:ContinuousIntegrationBuild=true \
             -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
             -o artifacts
+
+      # Guard against an irreversible push of a non-shipping package (nuget.org
+      # packages cannot be deleted, only unlisted). Samples/tests/the e2e demo are
+      # IsPackable=false; this catches any future project that forgets to opt out.
+      - name: Verify only shipping packages are staged
+        run: |
+          set -euo pipefail
+          if ls artifacts/ | grep -iE 'benchmark|sample|test|demo'; then
+            echo "::error::A non-shipping package is staged in artifacts/ — aborting before push."
+            exit 1
+          fi
+          echo "Packages to publish:"; ls -1 artifacts/*.nupkg
 
       # Exchange the GitHub OIDC token for a short-lived nuget.org API key.
       # Requires a Trusted Publisher policy on nuget.org + the NUGET_USER variable.
@@ -84,4 +100,4 @@ jobs:
         run: |
           PRERELEASE_FLAG=""
           if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then PRERELEASE_FLAG="--prerelease"; fi
-          gh release create "${GITHUB_REF_NAME}" --generate-notes $PRERELEASE_FLAG artifacts/*.nupkg
+          gh release create "${GITHUB_REF_NAME}" --generate-notes $PRERELEASE_FLAG artifacts/*.nupkg artifacts/*.snupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+# Publishes all NuGet packages + a GitHub Release when a vX.Y.Z tag is pushed.
+# Requires the NUGET_API_KEY secret (see RELEASING.md). The strong-name key is
+# committed in the repo, so no signing secret is needed.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # create the GitHub Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Derive & verify version
+        id: ver
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          BASE="${VERSION%%-*}"   # strip any -rc/-beta suffix for the props comparison
+          # VersionPrefix is "$(VersionMajor).$(VersionMinor).$(VersionPatch)" — resolve from the parts.
+          MAJOR="$(grep -oE '<VersionMajor>[0-9]+' build/version.props | grep -oE '[0-9]+')"
+          MINOR="$(grep -oE '<VersionMinor>[0-9]+' build/version.props | grep -oE '[0-9]+')"
+          PATCH="$(grep -oE '<VersionPatch>[0-9]+' build/version.props | grep -oE '[0-9]+')"
+          PROPS="${MAJOR}.${MINOR}.${PATCH}"
+          echo "tag version: $VERSION (base $BASE) · version.props: $PROPS"
+          if [ "$BASE" != "$PROPS" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME (base $BASE) does not match build/version.props VersionPrefix $PROPS. Bump version.props first."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then echo "prerelease=true" >> "$GITHUB_OUTPUT"; else echo "prerelease=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build protocol (codegen) first
+        run: dotnet build src/SkyApm.Transport.Protocol -c Release --no-restore
+
+      - name: Pack
+        run: |
+          dotnet pack skyapm-dotnet.sln -c Release --no-restore \
+            -p:Version=${{ steps.ver.outputs.version }} \
+            -p:ContinuousIntegrationBuild=true \
+            -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
+            -o artifacts
+
+      - name: Push packages to NuGet
+        run: |
+          dotnet nuget push "artifacts/*.nupkg" \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --skip-duplicate
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then PRERELEASE_FLAG="--prerelease"; fi
+          gh release create "${GITHUB_REF_NAME}" --generate-notes $PRERELEASE_FLAG artifacts/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
 # Publishes all NuGet packages + a GitHub Release when a vX.Y.Z tag is pushed.
-# Requires the NUGET_API_KEY secret (see RELEASING.md). The strong-name key is
-# committed in the repo, so no signing secret is needed.
+# Uses NuGet **Trusted Publishing** (OIDC) — no API-key secret to store. Configure
+# a trusted-publisher policy on nuget.org (repo + this workflow) and set the
+# NUGET_USER repo variable; see RELEASING.md. The strong-name key is committed,
+# so no signing secret is needed either.
 
 on:
   push:
@@ -11,6 +13,7 @@ on:
 
 permissions:
   contents: write   # create the GitHub Release
+  id-token: write   # OIDC token for NuGet Trusted Publishing
 
 jobs:
   release:
@@ -60,11 +63,19 @@ jobs:
             -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
             -o artifacts
 
+      # Exchange the GitHub OIDC token for a short-lived nuget.org API key.
+      # Requires a Trusted Publisher policy on nuget.org + the NUGET_USER variable.
+      - name: NuGet login (Trusted Publishing / OIDC)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       - name: Push packages to NuGet
         run: |
           dotnet nuget push "artifacts/*.nupkg" \
             --source https://api.nuget.org/v3/index.json \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,38 @@
 name: Release
 
-# Publishes all NuGet packages + a GitHub Release when a vX.Y.Z tag is pushed.
-# Uses NuGet **Trusted Publishing** (OIDC) — no API-key secret to store. Configure
-# a trusted-publisher policy on nuget.org (repo + this workflow) and set the
-# NUGET_USER repo variable; see RELEASING.md. The strong-name key is committed,
-# so no signing secret is needed either.
+# Manually-run release. From the Actions tab → "Release" → "Run workflow", enter
+# the release version and the next development version. The job then:
+#   1. bumps build/version.props to the release version, commits & pushes it,
+#   2. tags v<release> and pushes the tag,
+#   3. packs + publishes all NuGet packages (Trusted Publishing / OIDC),
+#   4. creates a GitHub Release on the tag,
+#   5. opens a PR bumping build/version.props to the next development version.
+#
+# It is dispatch-driven and does NOT trigger off a tag push. NuGet auth uses
+# Trusted Publishing — no API-key secret. Configure a trusted-publisher policy on
+# nuget.org (Workflow file: release.yml) and the NUGET_USER repo variable; see
+# RELEASING.md. The strong-name key is committed, so no signing secret either.
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version to publish, e.g. 2.3.0 (or 2.4.0-rc1 for a prerelease)'
+        required: true
+        type: string
+      next_version:
+        description: 'Next development version (number only), e.g. 2.4.0'
+        required: true
+        type: string
 
 permissions:
-  contents: write   # create the GitHub Release
-  id-token: write   # OIDC token for NuGet Trusted Publishing
+  contents: write        # commit the bump, push the tag, create the Release
+  id-token: write        # OIDC for NuGet Trusted Publishing
+  pull-requests: write   # open the next-version PR
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -30,26 +49,38 @@ jobs:
             8.0.x
             10.0.x
 
-      - name: Derive & verify version
+      - name: Validate inputs & resolve versions
         id: ver
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          BASE="${VERSION%%-*}"   # strip any -rc/-beta suffix for the props comparison
-          # VersionPrefix is "$(VersionMajor).$(VersionMinor).$(VersionPatch)" — resolve from the parts.
-          read_part() { grep -oE "<$1>[0-9]+</$1>" build/version.props | grep -oE '[0-9]+' | head -1 || true; }
-          MAJOR="$(read_part VersionMajor)"; MINOR="$(read_part VersionMinor)"; PATCH="$(read_part VersionPatch)"
-          for p in MAJOR MINOR PATCH; do
-            [ -n "${!p}" ] || { echo "::error::could not read Version$p from build/version.props"; exit 1; }
-          done
-          PROPS="${MAJOR}.${MINOR}.${PATCH}"
-          echo "tag version: $VERSION (base $BASE) · version.props: $PROPS"
-          if [ "$BASE" != "$PROPS" ]; then
-            echo "::error::Tag $GITHUB_REF_NAME (base $BASE) does not match build/version.props VersionPrefix $PROPS. Bump version.props first."
-            exit 1
+          REL="${{ inputs.release_version }}"
+          NEXT="${{ inputs.next_version }}"
+          [[ "$REL"  =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || { echo "::error::release_version '$REL' is not X.Y.Z[-suffix]"; exit 1; }
+          [[ "$NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]                  || { echo "::error::next_version '$NEXT' is not X.Y.Z"; exit 1; }
+          BASE="${REL%%-*}"
+          {
+            echo "release=$REL"
+            echo "base=$BASE"
+            echo "next=$NEXT"
+            echo "tag=v$REL"
+            if [[ "$REL" == *-* ]]; then echo "prerelease=true"; else echo "prerelease=false"; fi
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bump version & commit
+        env:
+          REL:  ${{ steps.ver.outputs.release }}
+          BASE: ${{ steps.ver.outputs.base }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          bash build/set-version.sh "$BASE"
+          if git diff --quiet -- build/version.props; then
+            echo "version.props already at $BASE — no release commit needed"
+          else
+            git commit -m "Release $REL" build/version.props
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          if [[ "$VERSION" == *-* ]]; then echo "prerelease=true" >> "$GITHUB_OUTPUT"; else echo "prerelease=false" >> "$GITHUB_OUTPUT"; fi
 
       - name: Restore
         run: dotnet restore
@@ -62,14 +93,14 @@ jobs:
       - name: Pack
         run: |
           dotnet pack skyapm-dotnet.sln -c Release --no-restore \
-            -p:Version=${{ steps.ver.outputs.version }} \
+            -p:Version=${{ steps.ver.outputs.release }} \
             -p:ContinuousIntegrationBuild=true \
             -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
             -o artifacts
 
       # Guard against an irreversible push of a non-shipping package (nuget.org
-      # packages cannot be deleted, only unlisted). Samples/tests/the e2e demo are
-      # IsPackable=false; this catches any future project that forgets to opt out.
+      # packages cannot be deleted, only unlisted). Samples/tests/benchmark/the e2e
+      # demo are IsPackable=false; this catches any future project that forgets to.
       - name: Verify only shipping packages are staged
         run: |
           set -euo pipefail
@@ -94,10 +125,43 @@ jobs:
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
+      # Tag only after a successful publish, so a failed publish leaves no orphan
+      # tag/Release; the run is then retryable (the bump commit is idempotent).
+      - name: Tag the release
+        env:
+          REL: ${{ steps.ver.outputs.release }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git tag -a "$TAG" -m "Release $REL"
+          git push origin "$TAG"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
         run: |
+          set -euo pipefail
           PRERELEASE_FLAG=""
           if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then PRERELEASE_FLAG="--prerelease"; fi
-          gh release create "${GITHUB_REF_NAME}" --generate-notes $PRERELEASE_FLAG artifacts/*.nupkg artifacts/*.snupkg
+          gh release create "$TAG" --generate-notes $PRERELEASE_FLAG artifacts/*.nupkg artifacts/*.snupkg
+
+      - name: Open next-version PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REL:  ${{ steps.ver.outputs.release }}
+          NEXT: ${{ steps.ver.outputs.next }}
+        run: |
+          set -euo pipefail
+          bash build/set-version.sh "$NEXT"
+          if git diff --quiet -- build/version.props; then
+            echo "version.props already at $NEXT — no next-version PR needed"
+            exit 0
+          fi
+          BR="chore/bump-to-${NEXT}"
+          git checkout -b "$BR"
+          git commit -m "Prepare for next development version $NEXT" build/version.props
+          git push --force-with-lease origin "$BR"
+          gh pr create --base "${GITHUB_REF_NAME}" --head "$BR" \
+            --title "Prepare for next development version $NEXT" \
+            --body "Bumps \`build/version.props\` to \`$NEXT\` following the \`$REL\` release. Opened automatically by the Release workflow."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,4 @@ themes/hugo-... , hugo.toml, i18n/   docs site theme + config (.github/workflows
 - Plugins: a fixed default set is auto-registered; others are opt-in via the `AddSkyAPM(ext => …)` lambda.
 - The repo also pins per-TFM package versions via `Condition="'$(TargetFramework)' == 'netX'"` blocks.
 - Project is **independent** — reports to Apache SkyWalking but is not an ASF/SkyWalking sub-project.
+- Commits: do **not** add a `Co-Authored-By: Claude …` trailer (or any AI co-author trailer) to commit messages.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,8 +3,9 @@
 Status: **proposed automation** · Goal: pushing a `vX.Y.Z` tag **automatically** builds, packs,
 signs, publishes all NuGet packages to nuget.org, and creates a GitHub Release.
 
-The draft workflow that implements this is [`.github/workflows/release.yml`](.github/workflows/release.yml).
-It is inert until the `NUGET_API_KEY` secret is added (see [§4](#4-one-time-setup)).
+The workflow that implements this is [`.github/workflows/release.yml`](.github/workflows/release.yml).
+It is inert until a NuGet **Trusted Publisher** policy + the `NUGET_USER` repo variable are configured
+(see [§4](#4-one-time-setup-nuget-trusted-publishing--no-api-key)).
 
 ---
 
@@ -35,7 +36,9 @@ It is inert until the `NUGET_API_KEY` secret is added (see [§4](#4-one-time-set
    `dotnet pack -p:Version=$VERSION -p:ContinuousIntegrationBuild=true -p:SymbolPackageFormat=snupkg`
    → `./artifacts`. (Samples are excluded via `sample/Directory.Build.props` → `IsPackable=false`;
    test projects are already `IsPackable=false`.)
-5. **Pushes** `*.nupkg` + `*.snupkg` to nuget.org with `--skip-duplicate` (re-runs are safe).
+5. **Authenticates via OIDC** — the `NuGet/login` action exchanges the GitHub OIDC token for a
+   short-lived nuget.org key (Trusted Publishing; needs `permissions: id-token: write`) — then
+   **pushes** `*.nupkg` + `*.snupkg` with `--skip-duplicate` (re-runs are safe).
 6. **Creates a GitHub Release** for the tag with auto-generated notes
    (`gh release create --generate-notes`), marked **prerelease** when the tag has a `-suffix`.
 
@@ -53,12 +56,25 @@ It is inert until the `NUGET_API_KEY` secret is added (see [§4](#4-one-time-set
 4. **Prereleases:** tag like `v2.4.0-rc1` → published as a NuGet prerelease and a GitHub
    *pre-release*. (`version.props` may stay at `2.4.0`; only the base is compared.)
 
-## 4. One-time setup
+## 4. One-time setup (NuGet Trusted Publishing — no API key)
 
-- **Add the `NUGET_API_KEY` secret** (repo → Settings → Secrets and variables → Actions, or at the
-  SkyAPM org level). Create the key on nuget.org scoped to **Glob `SkyApm.*` and `SkyAPM.*`** with
-  push + push-new-package rights.
-- That's the only required secret. The strong-name key is already in the repo.
+NuGet.org recommends **Trusted Publishing** (OIDC) over long-lived API keys for CI. Set it up once —
+**no secret is stored**:
+
+1. **Create a trusted-publisher policy on nuget.org.** Sign in with the account that owns the
+   `SkyApm.*` / `SkyAPM.*` packages → **Account → Trusted Publishing → Add** → **GitHub Actions**:
+   - Repository owner `SkyAPM`, repository `SkyAPM-dotnet`
+   - Workflow file `release.yml`
+   - (optional) restrict to the `SkyApm.*` / `SkyAPM.*` package glob
+2. **Add a `NUGET_USER` repo variable** (repo → Settings → Secrets and variables → Actions →
+   **Variables**, or at the SkyAPM org level) = your nuget.org username (the policy owner). This is a
+   plain *variable*, not a secret.
+
+The strong-name key is already committed, so there is no signing secret either. The workflow's
+`permissions: id-token: write` (already set) lets `NuGet/login` perform the OIDC exchange.
+
+> **Fallback:** for local/manual publishing or unsupported CI, an API key still works:
+> `dotnet nuget push <pkg> --api-key <key> --source https://api.nuget.org/v3/index.json`.
 
 ## 5. Decisions taken (no-ask defaults) & open questions
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,8 +77,10 @@ NuGet.org recommends **Trusted Publishing** (OIDC) over long-lived API keys for 
    > repo/owner IDs (resurrection-attack protection). Only relevant if the repo is private —
    > SkyAPM-dotnet is public, so it activates permanently on the first publish.
 2. **Add a `NUGET_USER` repo variable** (repo → Settings → Secrets and variables → Actions →
-   **Variables**, or at the SkyAPM org level) = your nuget.org username (the policy owner). This is a
-   plain *variable*, not a secret.
+   **Variables**, or at the SkyAPM org level) = your **individual nuget.org username / profile name**
+   (e.g. `wu-sheng`) — **not** your email, and **not** the org name, even when the policy *owner* is
+   the `skyapm` org. You must stay an active member of that org for the policy to remain valid. This
+   is a plain *variable*, not a secret.
 
 The strong-name key is already committed, so there is no signing secret either. The workflow's
 `permissions: id-token: write` (already set) lets `NuGet/login` perform the OIDC exchange.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,12 +52,19 @@ It is inert until a NuGet **Trusted Publisher** policy + the `NUGET_USER` repo v
 ## 3. Cutting a release
 
 1. Go to **Actions → Release → Run workflow** and enter:
-   - **release_version** — e.g. `2.3.0` (or `2.4.0-rc1` for a prerelease)
-   - **next_version** — the next development version, e.g. `2.4.0`
+   - **release_version** — e.g. `2.3.0` (or `2.3.0-rc1` for a prerelease)
+   - **next_version** — the next development version, a **plain number** e.g. `2.4.0`
 2. The run bumps + commits + tags, publishes to nuget.org, creates the GitHub Release, and opens the
    next-version PR. **Merge that PR** to continue development on `next_version`.
-3. **Prereleases:** `release_version` `2.4.0-rc1` → published as a NuGet prerelease + GitHub
-   *pre-release*; `version.props` is set to the base `2.4.0`.
+3. **Prereleases (e.g. an RC):** set `release_version` to `2.3.0-rc1` → published as a NuGet
+   prerelease + GitHub *pre-release*; `version.props` is set to the base `2.3.0`. **For an RC, set
+   `next_version` to the same base** (`2.3.0`) — the next-version PR is then skipped, so you don't
+   prematurely bump to the next minor before the stable release. (An RC whose base equals the current
+   `version.props` makes no release commit at all — only the tag — so it doesn't touch `main`.)
+
+> **Dev-version convention:** `version.props` carries a **plain** number between releases (no
+> `-dev`/`-preview` suffix). That matches every committed version in this repo's history — the old
+> `-preview`/`-dev` suffixes were build-time stamps from the (now-unused) Cake script, never committed.
 
 > **Requirements:** the workflow pushes the release commit + tag directly, so branch protection on
 > the run branch must allow the `github-actions` bot to push (or have no direct-push restriction).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,6 +42,10 @@ It is inert until a NuGet **Trusted Publisher** policy + the `NUGET_USER` repo v
 6. **Creates a GitHub Release** for the tag with auto-generated notes
    (`gh release create --generate-notes`), marked **prerelease** when the tag has a `-suffix`.
 
+> The Actions path derives the version from the **tag** (and prerelease from its `-suffix`), so
+> `VersionQuality` / `build/version.cake` are **not** consulted — editing them has no effect on a
+> GitHub Actions release.
+
 ## 3. Cutting a release
 
 1. **Bump the version** in `build/version.props` (`VersionMajor`/`Minor`/`Patch`) on a PR and merge
@@ -62,10 +66,16 @@ NuGet.org recommends **Trusted Publishing** (OIDC) over long-lived API keys for 
 **no secret is stored**:
 
 1. **Create a trusted-publisher policy on nuget.org.** Sign in with the account that owns the
-   `SkyApm.*` / `SkyAPM.*` packages → **Account → Trusted Publishing → Add** → **GitHub Actions**:
-   - Repository owner `SkyAPM`, repository `SkyAPM-dotnet`
-   - Workflow file `release.yml`
-   - (optional) restrict to the `SkyApm.*` / `SkyAPM.*` package glob
+   `SkyApm.*` / `SkyAPM.*` packages → click your **username → Trusted Publishing** → add a new policy:
+   - **Policy owner:** the nuget.org user/org that owns the packages. Trusted Publishing has **no
+     per-package glob** — the policy covers *all* packages owned by the selected owner.
+   - **Repository owner** `SkyAPM`, **Repository** `SkyAPM-dotnet`
+   - **Workflow file** `release.yml` — the file name only, **not** the `.github/workflows/` path
+   - (leave Environment empty — the workflow doesn't use a GitHub Environment)
+
+   > A new policy is "temporarily active for 7 days" until the first successful publish locks in the
+   > repo/owner IDs (resurrection-attack protection). Only relevant if the repo is private —
+   > SkyAPM-dotnet is public, so it activates permanently on the first publish.
 2. **Add a `NUGET_USER` repo variable** (repo → Settings → Secrets and variables → Actions →
    **Variables**, or at the SkyAPM org level) = your nuget.org username (the policy owner). This is a
    plain *variable*, not a secret.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,8 @@
 # Releasing SkyAPM-dotnet
 
-Status: **proposed automation** · Goal: pushing a `vX.Y.Z` tag **automatically** builds, packs,
-signs, publishes all NuGet packages to nuget.org, and creates a GitHub Release.
+Status: **automated** · Goal: one manual *Run workflow* click **bumps** the version, commits, tags,
+packs + publishes all NuGet packages to nuget.org, creates a GitHub Release, and opens the
+next-development-version PR.
 
 The workflow that implements this is [`.github/workflows/release.yml`](.github/workflows/release.yml).
 It is inert until a NuGet **Trusted Publisher** policy + the `NUGET_USER` repo variable are configured
@@ -16,8 +17,8 @@ It is inert until a NuGet **Trusted Publisher** policy + the `NUGET_USER` repo v
 - **Version** comes from `build/version.props` (`VersionPrefix`, currently `2.3.0`).
 - **Signing** is strong-name via `build/SkyAPM.snk`, which is **committed** in the repo → no signing
   secret is needed; the workflow only needs to build in `Release`.
-- **CI today** (`.github/workflows/net-ci-it.yml`) already triggers on `v*` tags but only
-  **builds/tests** — it never packs or pushes. Releasing is currently manual.
+- **CI** (`.github/workflows/net-ci-it.yml`) builds/tests on pushes and PRs; it never packs or
+  pushes. Packing/publishing lives only in `release.yml`.
 - **The Cake script is stale** for releasing: `build/version.cake` detects tags only on
   AppVeyor/Travis (not GitHub Actions), so a tag build under GHA would wrongly emit a
   `-preview-<stamp>` suffix; it also globs a non-existent `./cli` path. → The release workflow uses
@@ -25,40 +26,42 @@ It is inert until a NuGet **Trusted Publisher** policy + the `NUGET_USER` repo v
 
 ## 2. How the automated release works
 
-`release.yml` triggers on **`push: tags: ['v*']`** and:
+`release.yml` is **manually dispatched** (Actions tab → *Release* → *Run workflow*) with two inputs —
+`release_version` and `next_version` — and is **not** triggered by a tag. One run does everything:
 
-1. **Checks out with submodules** (`recursive`) so the `protocol-v3` protobuf source is present.
-2. **Sets up .NET 8 + 10.**
-3. **Derives and verifies the version:** `VERSION=${GITHUB_REF_NAME#v}` and asserts that its base
-   (without any `-rc`/`-beta` suffix) equals `VersionPrefix` in `build/version.props`. A mismatch
-   **fails the job** — preventing a `v2.3.0` tag from publishing a differently-numbered package.
-4. **Builds the protocol project first**, then **packs the solution** in `Release`:
-   `dotnet pack -p:Version=$VERSION -p:ContinuousIntegrationBuild=true -p:SymbolPackageFormat=snupkg`
-   → `./artifacts`. (Samples are excluded via `sample/Directory.Build.props` → `IsPackable=false`;
-   test projects are already `IsPackable=false`.)
-5. **Authenticates via OIDC** — the `NuGet/login` action exchanges the GitHub OIDC token for a
-   short-lived nuget.org key (Trusted Publishing; needs `permissions: id-token: write`) — then
-   **pushes** `*.nupkg` + `*.snupkg` with `--skip-duplicate` (re-runs are safe).
-6. **Creates a GitHub Release** for the tag with auto-generated notes
-   (`gh release create --generate-notes`), marked **prerelease** when the tag has a `-suffix`.
+1. **Validates** the two inputs and **checks out with submodules** (`recursive`) + sets up .NET 8/10.
+2. **Bumps `build/version.props`** to the release version (via `build/set-version.sh`), **commits**
+   `Release <version>` and **pushes** to the branch it was run from (default `main`). If the file is
+   already at that version (e.g. it was pre-bumped), it skips the commit and just tags.
+3. **Tags** `v<release_version>` and pushes the tag.
+4. **Builds the protocol first**, then **packs the solution** in `Release`
+   (`dotnet pack -p:Version=<release_version> -p:SymbolPackageFormat=snupkg → ./artifacts`). Samples,
+   tests, the benchmark, and the e2e demo are `IsPackable=false`; a guard step **aborts before push**
+   if any non-shipping package slips into `artifacts/`.
+5. **Authenticates via OIDC** — `NuGet/login` exchanges the GitHub OIDC token for a short-lived
+   nuget.org key (Trusted Publishing; needs `permissions: id-token: write`) — then **pushes**
+   `*.nupkg` + `*.snupkg` with `--skip-duplicate` (re-runs are safe).
+6. **Creates a GitHub Release** on the tag with auto-generated notes, marked **prerelease** when the
+   release version has a `-suffix`.
+7. **Opens a PR** bumping `build/version.props` to `next_version` (`chore/bump-to-<next>`).
 
-> The Actions path derives the version from the **tag** (and prerelease from its `-suffix`), so
-> `VersionQuality` / `build/version.cake` are **not** consulted — editing them has no effect on a
-> GitHub Actions release.
+> The published version comes from the `release_version` **input**; `VersionQuality` /
+> `build/version.cake` are not consulted. The job runs `dotnet nuget push` from `release.yml`, so the
+> OIDC claim matches the nuget.org policy (whose *Workflow file* must be `release.yml`).
 
 ## 3. Cutting a release
 
-1. **Bump the version** in `build/version.props` (`VersionMajor`/`Minor`/`Patch`) on a PR and merge
-   it. (The consistency check in step 3 above turns a forgotten bump into a hard failure rather than
-   a mis-numbered publish.)
-2. **Tag and push:**
-   ```bash
-   git tag v2.3.0
-   git push origin v2.3.0
-   ```
-3. The **Release** workflow runs → packages on nuget.org + a GitHub Release appear.
-4. **Prereleases:** tag like `v2.4.0-rc1` → published as a NuGet prerelease and a GitHub
-   *pre-release*. (`version.props` may stay at `2.4.0`; only the base is compared.)
+1. Go to **Actions → Release → Run workflow** and enter:
+   - **release_version** — e.g. `2.3.0` (or `2.4.0-rc1` for a prerelease)
+   - **next_version** — the next development version, e.g. `2.4.0`
+2. The run bumps + commits + tags, publishes to nuget.org, creates the GitHub Release, and opens the
+   next-version PR. **Merge that PR** to continue development on `next_version`.
+3. **Prereleases:** `release_version` `2.4.0-rc1` → published as a NuGet prerelease + GitHub
+   *pre-release*; `version.props` is set to the base `2.4.0`.
+
+> **Requirements:** the workflow pushes the release commit + tag directly, so branch protection on
+> the run branch must allow the `github-actions` bot to push (or have no direct-push restriction).
+> The first run also needs the one-time setup in §4.
 
 ## 4. One-time setup (NuGet Trusted Publishing — no API key)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# Releasing SkyAPM-dotnet
+
+Status: **proposed automation** · Goal: pushing a `vX.Y.Z` tag **automatically** builds, packs,
+signs, publishes all NuGet packages to nuget.org, and creates a GitHub Release.
+
+The draft workflow that implements this is [`.github/workflows/release.yml`](.github/workflows/release.yml).
+It is inert until the `NUGET_API_KEY` secret is added (see [§4](#4-one-time-setup)).
+
+---
+
+## 1. Current state
+
+- **Packages:** ~30 packable libraries under `src/` (incl. the meta-packages `SkyAPM.Agent.AspNetCore`
+  / `SkyAPM.Agent.GeneralHost`) plus the `SkyApm.DotNet.CLI` global tool. Published to **nuget.org**.
+- **Version** comes from `build/version.props` (`VersionPrefix`, currently `2.3.0`).
+- **Signing** is strong-name via `build/SkyAPM.snk`, which is **committed** in the repo → no signing
+  secret is needed; the workflow only needs to build in `Release`.
+- **CI today** (`.github/workflows/net-ci-it.yml`) already triggers on `v*` tags but only
+  **builds/tests** — it never packs or pushes. Releasing is currently manual.
+- **The Cake script is stale** for releasing: `build/version.cake` detects tags only on
+  AppVeyor/Travis (not GitHub Actions), so a tag build under GHA would wrongly emit a
+  `-preview-<stamp>` suffix; it also globs a non-existent `./cli` path. → The release workflow uses
+  **plain `dotnet pack`**, not the Cake `Pack` task.
+
+## 2. How the automated release works
+
+`release.yml` triggers on **`push: tags: ['v*']`** and:
+
+1. **Checks out with submodules** (`recursive`) so the `protocol-v3` protobuf source is present.
+2. **Sets up .NET 8 + 10.**
+3. **Derives and verifies the version:** `VERSION=${GITHUB_REF_NAME#v}` and asserts that its base
+   (without any `-rc`/`-beta` suffix) equals `VersionPrefix` in `build/version.props`. A mismatch
+   **fails the job** — preventing a `v2.3.0` tag from publishing a differently-numbered package.
+4. **Builds the protocol project first**, then **packs the solution** in `Release`:
+   `dotnet pack -p:Version=$VERSION -p:ContinuousIntegrationBuild=true -p:SymbolPackageFormat=snupkg`
+   → `./artifacts`. (Samples are excluded via `sample/Directory.Build.props` → `IsPackable=false`;
+   test projects are already `IsPackable=false`.)
+5. **Pushes** `*.nupkg` + `*.snupkg` to nuget.org with `--skip-duplicate` (re-runs are safe).
+6. **Creates a GitHub Release** for the tag with auto-generated notes
+   (`gh release create --generate-notes`), marked **prerelease** when the tag has a `-suffix`.
+
+## 3. Cutting a release
+
+1. **Bump the version** in `build/version.props` (`VersionMajor`/`Minor`/`Patch`) on a PR and merge
+   it. (The consistency check in step 3 above turns a forgotten bump into a hard failure rather than
+   a mis-numbered publish.)
+2. **Tag and push:**
+   ```bash
+   git tag v2.3.0
+   git push origin v2.3.0
+   ```
+3. The **Release** workflow runs → packages on nuget.org + a GitHub Release appear.
+4. **Prereleases:** tag like `v2.4.0-rc1` → published as a NuGet prerelease and a GitHub
+   *pre-release*. (`version.props` may stay at `2.4.0`; only the base is compared.)
+
+## 4. One-time setup
+
+- **Add the `NUGET_API_KEY` secret** (repo → Settings → Secrets and variables → Actions, or at the
+  SkyAPM org level). Create the key on nuget.org scoped to **Glob `SkyApm.*` and `SkyAPM.*`** with
+  push + push-new-package rights.
+- That's the only required secret. The strong-name key is already in the repo.
+
+## 5. Decisions taken (no-ask defaults) & open questions
+
+**Defaults chosen:** publish target is **nuget.org only**; tag convention standardized on
+**`vX.Y.Z`** for both the code tag and the GitHub Release (older releases used a separate
+`vX.Y.Z-release` tag — dropped); symbols as **`.snupkg`**; the CLI global tool is published in the
+**same** release run and version; `net-ci-it.yml` keeps its `v*` trigger for build/test, while
+pack/push lives only in `release.yml`.
+
+**Open questions for review:** keep publishing prereleases to the myget `-vnext` feed on `main`
+pushes, or nuget.org only? `PackageRequireLicenseAcceptance=True` together with an SPDX
+`PackageLicenseExpression` triggers a nuget.org warning — consider dropping the former. Confirm the
+committed `SkyAPM.snk` is intentional identity-only signing (not to be rotated to a secret).

--- a/benchmark/SkyApm.Benchmark/SkyApm.Benchmark.csproj
+++ b/benchmark/SkyApm.Benchmark/SkyApm.Benchmark.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <!-- Internal benchmark harness — never publish it to nuget.org. -->
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <IsPackable>false</IsPackable>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 

--- a/build/set-version.sh
+++ b/build/set-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Set VersionMajor/Minor/Patch in build/version.props (VersionPrefix is derived).
+# Usage: build/set-version.sh X.Y.Z [path-to-version.props]
+# Portable across GNU/BSD sed (writes via a temp file, not sed -i).
+set -euo pipefail
+
+v="${1:?usage: set-version.sh X.Y.Z [version.props]}"
+f="${2:-"$(dirname "$0")/version.props"}"
+
+IFS=. read -r mj mn pt <<< "$v"
+{ [ -n "${mj:-}" ] && [ -n "${mn:-}" ] && [ -n "${pt:-}" ]; } \
+  || { echo "set-version: version must be X.Y.Z (got '$v')" >&2; exit 1; }
+case "${mj}${mn}${pt}" in *[!0-9]*) echo "set-version: version parts must be numeric (got '$v')" >&2; exit 1;; esac
+[ -f "$f" ] || { echo "set-version: file not found: $f" >&2; exit 1; }
+
+tmp="$(mktemp)"
+sed -E \
+  -e "s#<VersionMajor>[0-9]+</VersionMajor>#<VersionMajor>${mj}</VersionMajor>#" \
+  -e "s#<VersionMinor>[0-9]+</VersionMinor>#<VersionMinor>${mn}</VersionMinor>#" \
+  -e "s#<VersionPatch>[0-9]+</VersionPatch>#<VersionPatch>${pt}</VersionPatch>#" \
+  "$f" > "$tmp" && mv "$tmp" "$f"
+
+echo "set $(basename "$f") to ${mj}.${mn}.${pt}"

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <!-- Import the repo-root props (TargetFrameworks, common.props, version, signing). -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Sample apps are not published to NuGet. This keeps `dotnet pack` (release)
+         from emitting sample packages even though common.props sets
+         GeneratePackageOnBuild=True. -->
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
A manually-dispatched release process. From **Actions → Release → Run workflow**, enter `release_version` and `next_version`; one run does everything:

1. **Bumps** `build/version.props` to the release version (`build/set-version.sh`), commits `Release X` and pushes (idempotent if already at that version).
2. **Packs + publishes** all NuGet packages via **Trusted Publishing (OIDC)** — no API-key secret. A guard step aborts before push if any non-shipping package (benchmark/sample/test/demo) is staged.
3. **Tags** `vX` — only *after* a successful publish, so a failed publish leaves no orphan tag and the run is retryable.
4. **Creates the GitHub Release** on the tag (`--generate-notes`, prerelease-aware), attaching `.nupkg` + `.snupkg`.
5. **Opens a PR** bumping to `next_version`.

**Dispatch-driven, no tag trigger** (per request) — which also avoids the GITHUB_TOKEN-can't-trigger-workflows limitation and keeps `dotnet nuget push` inside `release.yml` so the OIDC claim matches the nuget.org trusted-publisher policy (whose *Workflow file* = `release.yml`).

Also fixed here (from the pre-release verification): `SkyApm.Benchmark` → `IsPackable=false` (would have published to nuget.org), the staging guard, snupkg on the Release, stray-protocol-nupkg suppression, hardened version parse, and corrected RELEASING.md Trusted Publishing setup steps. Includes the CLAUDE.md no-Co-Authored-By convention (folded in from #624).

### One-time setup
- nuget.org Trusted Publishing policy (Workflow file `release.yml`) owned by the account/org that owns the `SkyApm.*`/`SkyAPM.*` packages.
- `NUGET_USER` repo **variable** = your nuget.org username (e.g. `wu-sheng`).
- Branch protection on `main` must allow the `github-actions` bot to push the release commit + tag.

See [RELEASING.md](RELEASING.md).