### PR TITLE
fix(release): pass -p:GeneratePackageOnBuild=false to Pack (fixes NU5026)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,14 @@ jobs:
         run: dotnet build src/SkyApm.Transport.Protocol -c Release --no-restore -p:GeneratePackageOnBuild=false
 
       - name: Pack
+        # -p:GeneratePackageOnBuild=false is REQUIRED: build/common.props sets it true
+        # globally, which makes `dotnet pack` try to pack-on-build before all TFMs
+        # (net8/net10/netstandard2.0) are built — failing with NU5026 "dll not found".
         run: |
           dotnet pack skyapm-dotnet.sln -c Release --no-restore \
             -p:Version=${{ steps.ver.outputs.release }} \
             -p:ContinuousIntegrationBuild=true \
+            -p:GeneratePackageOnBuild=false \
             -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg \
             -o artifacts
 


### PR DESCRIPTION
The first real release run failed at **Pack** ([run](https://github.com/SkyAPM/SkyAPM-dotnet/actions/runs/28309299537)) with `NU5026: ... net10.0/<lib>.dll to be packed was not found on disk` for nearly every multi-targeted library.

**Root cause:** `build/common.props` sets `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` globally. When `dotnet pack` runs the solution, that fires a *pack-on-build* that races ahead of the multi-TFM build and tries to pack before the `net10.0` output exists. `SkyApm.DotNet.CLI` (which sets `GeneratePackageOnBuild=false`) and the protocol packed fine — confirming the cause.

**Fix:** pass `-p:GeneratePackageOnBuild=false` to the Pack command, so the single explicit Pack runs after a complete build.

**Verified locally** (mirrors the CI steps): pack exits 0, **0 NU5026**, produces **31 `.nupkg` + 31 `.snupkg`**, and no benchmark/sample/test packages.

The failed run did **not** publish anything or create a tag/commit (it died at Pack, before those steps), so no cleanup is needed.