### PR TITLE
fix(release): correct SPDX license id (APACHE-2.0 → Apache-2.0)

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -8,7 +8,7 @@
         <PackagePrefix>SkyAPM</PackagePrefix>
         <PackageIconUrl>https://avatars2.githubusercontent.com/u/32165127</PackageIconUrl>
         <PackageProjectUrl>https://github.com/SkyAPM/SkyAPM-dotnet</PackageProjectUrl>
-        <PackageLicenseExpression>APACHE-2.0</PackageLicenseExpression>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/SkyAPM/SkyAPM-dotnet</RepositoryUrl>
         <GenerateAssemblyConfigurationAttribute>True</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
The RC publish reached nuget.org (Pack ✓, **Trusted Publishing/OIDC ✓**) but was **rejected at push** ([run](https://github.com/SkyAPM/SkyAPM-dotnet/actions/runs/28309736013)):

```
400 (Invalid license metadata: The license identifier(s) 'APACHE-2.0' is(are) not recognized by the current toolset.)
```

SPDX license identifiers are **case-sensitive** — the canonical id is **`Apache-2.0`**. `build/common.props` had `APACHE-2.0`, which only *warns* (NU5124) at pack time but nuget.org enforces as a hard **400** at push.

**Fix:** `PackageLicenseExpression` → `Apache-2.0` (one line, shared by all packages via `common.props`).

**Verified** by packing `SkyApm.Abstractions` and inspecting the `.nuspec`:
```
<license type="expression">Apache-2.0</license>
<licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
```
No `NU5124`. The earlier `NU5026` fix is already on `main` (Pack now succeeds). The failed run published **nothing** and created no tag (it died on the first package's push), so no cleanup is needed.

> Out of scope (warnings only, nuget.org accepts them): deprecated `PackageIconUrl` (NU5048) and `RequireLicenseAcceptance=true`. Can clean up separately if desired.