### PR TITLE
ci(e2e): run on any code/package change (deny-list), skip only docs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,22 +2,40 @@ name: E2E
 
 # Builds the .NET 8 / .NET 10 demo services (agent from source), boots a pinned
 # SkyWalking OAP + BanyanDB, and verifies trace/log/metric reached OAP.
-# Heavy (~10-15 min), so it only runs when the agent or the e2e changes.
+#
+# Runs on any change that could affect code or packaging — and SKIPS only pure
+# docs/website and CI-config changes. This is a deny-list (paths-ignore) on
+# purpose: any new code/build path triggers e2e automatically, which is safer
+# than an allow-list that silently misses things (e.g. build/** previously did).
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'src/**'
-      - 'test/e2e/**'
-      - '.dockerignore'
-      - '.github/workflows/e2e.yml'
+    paths-ignore:
+      - '**/*.md'
+      - 'content/**'
+      - 'themes/**'
+      - 'i18n/**'
+      - 'layouts/**'
+      - 'static/**'
+      - 'hugo.toml'
+      - 'LICENSE'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/net-ci-it.yml'
   pull_request:
-    paths:
-      - 'src/**'
-      - 'test/e2e/**'
-      - '.dockerignore'
-      - '.github/workflows/e2e.yml'
+    paths-ignore:
+      - '**/*.md'
+      - 'content/**'
+      - 'themes/**'
+      - 'i18n/**'
+      - 'layouts/**'
+      - 'static/**'
+      - 'hugo.toml'
+      - 'LICENSE'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/net-ci-it.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Per request: e2e should run for **any potential code/package change**, as a safety net.

The old trigger was an **allow-list** (`paths: src/**, test/e2e/**, .dockerignore, e2e.yml`) — it silently skipped code/package changes elsewhere, e.g. `build/**` (shared MSBuild props imported by every project), `Directory.Build.props`, `NuGet.config`, and the `.sln`. That's why the release-fix PRs didn't run e2e.

**Fix:** switch to a **deny-list** (`paths-ignore`). e2e now runs for everything **except** pure docs/website and CI-config:
`**/*.md`, `content/**`, `themes/**`, `i18n/**`, `layouts/**`, `static/**`, `hugo.toml`, `LICENSE`, `.github/workflows/docs.yml`, `release.yml`, `net-ci-it.yml`.

Safer by default — any new code/build path triggers e2e automatically instead of being silently missed. A mixed PR (code + docs) still runs e2e (paths-ignore only skips when *all* changed files match).

This PR touches `e2e.yml` (not ignored), so it self-validates by running e2e.