### PR TITLE
fix(transport): reuse gRPC channel to stop socket churn when OAP is unavailable (#608)

### DIFF
--- a/src/SkyApm.Transport.Grpc/ConnectService.cs
+++ b/src/SkyApm.Transport.Grpc/ConnectService.cs
@@ -25,7 +25,21 @@ namespace SkyApm.Transport.Grpc
 {
     public class ConnectService: ExecutionService
     {
+        // The timer ticks at BasePeriod; while the server is unreachable, reconnect attempts back off
+        // exponentially up to MaxBackoff so a long outage doesn't rebuild a channel every tick (issue #608).
+        private static readonly TimeSpan BasePeriod = TimeSpan.FromSeconds(15);
+        private static readonly TimeSpan MaxBackoff = TimeSpan.FromMinutes(5);
+
         private readonly ConnectionManager _connectionManager;
+
+        // _running guards against re-entrancy: the base timer is periodic and its callback is async void,
+        // so it re-fires every BasePeriod even while a previous connect attempt is still awaiting (a probe
+        // can take up to ConnectTimeout). Without this guard, attempts would stack up and rebuild a channel
+        // per tick, defeating the backoff (issue #608). Because it serialises ExecuteAsync, _backoff and
+        // _nextAttemptUtc are only ever touched by a single thread and need no further synchronisation.
+        private int _running;
+        private TimeSpan _backoff = BasePeriod;
+        private DateTime _nextAttemptUtc = DateTime.MinValue;
 
         public ConnectService(ConnectionManager connectionManager,
             IRuntimeEnvironment runtimeEnvironment,
@@ -35,16 +49,54 @@ namespace SkyApm.Transport.Grpc
         }
 
         protected override TimeSpan DueTime { get; } = TimeSpan.Zero;
-        protected override TimeSpan Period { get; } = TimeSpan.FromSeconds(15);
+        protected override TimeSpan Period { get; } = BasePeriod;
 
         protected override async Task ExecuteAsync(CancellationToken cancellationToken)
         {
-            if (!_connectionManager.Ready)
+            if (Interlocked.CompareExchange(ref _running, 1, 0) != 0)
             {
-                await _connectionManager.ConnectAsync();
+                // A previous attempt is still in flight; skip this tick.
+                return;
+            }
+
+            try
+            {
+                if (DateTime.UtcNow < _nextAttemptUtc)
+                {
+                    // Still inside the backoff window: skip until it elapses.
+                    return;
+                }
+
+                if (!_connectionManager.Ready)
+                {
+                    await _connectionManager.ConnectAsync(cancellationToken);
+                }
+
+                if (_connectionManager.Ready)
+                {
+                    // Connected: reset backoff so the next outage reconnects immediately.
+                    _backoff = BasePeriod;
+                    _nextAttemptUtc = DateTime.MinValue;
+                }
+                else
+                {
+                    // Still unreachable: defer the next attempt by the current backoff,
+                    // then grow it (capped at MaxBackoff) for the attempt after.
+                    _nextAttemptUtc = DateTime.UtcNow.Add(_backoff);
+                    var doubled = TimeSpan.FromTicks(_backoff.Ticks * 2);
+                    _backoff = doubled < MaxBackoff ? doubled : MaxBackoff;
+                }
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _running, 0);
             }
         }
 
         protected override bool CanExecute() => !_connectionManager.Ready;
+
+        // Dispose the reused channel when the agent shuts down.
+        protected override Task Stopping(CancellationToken cancellationToken)
+            => _connectionManager.ShutdownAsync();
     }
 }

--- a/src/SkyApm.Transport.Grpc/ConnectionManager.cs
+++ b/src/SkyApm.Transport.Grpc/ConnectionManager.cs
@@ -22,12 +22,15 @@ using SkyApm.Logging;
 using SkyApm.Transport.Grpc.Common;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SkyApm.Transport.Grpc
 {
     public class ConnectionManager
     {
+        private const int DefaultConnectTimeoutMs = 10000;
+
         private readonly Random _random = new Random();
         private readonly AsyncLock _lock = new AsyncLock();
 
@@ -46,59 +49,106 @@ namespace SkyApm.Transport.Grpc
             _config = configAccessor.Get<GrpcConfig>();
         }
 
-        public async Task ConnectAsync()
+        public async Task ConnectAsync(CancellationToken cancellationToken = default)
         {
             using (await _lock.LockAsync())
             {
-                if (Ready)
+                // Bail out once the agent is shutting down so a late tick can't rebuild a channel after
+                // ShutdownAsync has already disposed it (which nothing would dispose again).
+                if (Ready || cancellationToken.IsCancellationRequested)
                 {
                     return;
                 }
 
-                if (_channel != null)
-                {
-                    await ShutdownAsync();
-                }
-
-                EnsureServerAddress();
-                
                 try
                 {
-                    //https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.0#call-insecure-grpc-services-with-net-core-client-2
-                    AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-                    
-                    _channel = GrpcChannel.ForAddress(_server, new GrpcChannelOptions { DisposeHttpClient = true });
+                    var servers = _config.GetServers();
+
+                    // Reuse the channel across transient failures: a GrpcChannel is long-lived and
+                    // re-establishes its underlying HTTP/2 connection on its own. Tearing it down and
+                    // rebuilding on every failure was the root cause of the socket churn / port exhaustion
+                    // in issue #608. Only (re)build when there is no channel yet, or when multiple servers
+                    // are configured and we rotate to a different one for failover (paced by the caller's
+                    // backoff). A single-server setup therefore reuses one channel for the whole process.
+                    if (_channel == null || servers.Length > 1)
+                    {
+                        await DisposeChannelAsync();
+                        EnsureServerAddress();
+                        //https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.0#call-insecure-grpc-services-with-net-core-client-2
+                        AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+                        _channel = GrpcChannel.ForAddress(_server, new GrpcChannelOptions { DisposeHttpClient = true });
+                    }
+
+#if NET6_0_OR_GREATER
+                    // GrpcChannel.ForAddress is lazy: it never opens a socket. Probe connectivity on the
+                    // (reused) channel, bounded by ConnectTimeout, so an unreachable server is reported as a
+                    // failure (circuit open) instead of a false "Connected". GrpcChannel.ConnectAsync only
+                    // exists on the net6.0+ assets of Grpc.Net.Client (gated by SUPPORT_LOAD_BALANCING); the
+                    // netstandard2.0 build optimistically marks Connected and lets the next RPC validate --
+                    // the channel is still reused, so there is no churn.
+                    // Cancel the probe on either the configured ConnectTimeout or agent shutdown, so a long
+                    // ConnectTimeout cannot stall graceful shutdown.
+                    var connectTimeout = _config.ConnectTimeout > 0 ? _config.ConnectTimeout : DefaultConnectTimeoutMs;
+                    using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+                    {
+                        cts.CancelAfter(connectTimeout);
+                        await _channel.ConnectAsync(cts.Token);
+                    }
+#endif
+
                     _state = ConnectionState.Connected;
                     _logger.Information($"Connected server[{_channel.Target}].");
                 }
-                catch (TaskCanceledException ex)
+                catch (OperationCanceledException ex)
                 {
+                    // Keep the channel for reuse; only the circuit opens. Skip the noisy log when the
+                    // cancellation is agent shutdown rather than a connect timeout.
                     _state = ConnectionState.Failure;
-                    _logger.Error($"Connect server timeout.", ex);
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.Error("Connect server timeout.", ex);
+                    }
                 }
                 catch (Exception ex)
                 {
                     _state = ConnectionState.Failure;
-                    _logger.Error($"Connect server fail.", ex);
+                    _logger.Error("Connect server fail.", ex);
                 }
             }
         }
 
         public async Task ShutdownAsync()
         {
+            using (await _lock.LockAsync())
+            {
+                await DisposeChannelAsync();
+                _state = ConnectionState.Failure;
+            }
+        }
+
+        // Disposes the current channel (and its HttpClient via DisposeHttpClient=true). Callers must hold
+        // _lock; it is invoked both from ConnectAsync (server rotation) and ShutdownAsync (agent stop).
+        private async Task DisposeChannelAsync()
+        {
+            var channel = _channel;
+            if (channel == null)
+            {
+                return;
+            }
+
+            _channel = null;
             try
             {
-                await _channel?.ShutdownAsync();
-                _logger.Information($"Shutdown connection[{_channel.Target}].");
+                await channel.ShutdownAsync();
+                _logger.Information($"Shutdown connection[{channel.Target}].");
             }
             catch (Exception e)
             {
-                _logger.Error($"Shutdown connection fail.", e);
+                _logger.Error("Shutdown connection fail.", e);
             }
             finally
             {
-                _channel?.Dispose();
-                _state = ConnectionState.Failure;
+                channel.Dispose();
             }
         }
 


### PR DESCRIPTION
## Problem

When the SkyWalking OAP server is unavailable, the agent runs out of TCP/ephemeral ports (`An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full`). Reported in #608, with 1000+ connections stuck in `Bound` state.

## Root cause

`GrpcChannel.ForAddress` is **lazy** — it opens no socket. `ConnectionManager.ConnectAsync` set the state to `Connected` immediately after building the channel, so an unreachable server was reported as connected. The first telemetry RPC then failed → `Failure()` flipped the state → `ConnectService` (a 15s timer) **rebuilt a brand-new `GrpcChannel` every 15s**. Each rebuild created a fresh `HttpClient` / `SocketsHttpHandler` whose half-open sockets accumulated in `Bound`/`TIME_WAIT` faster than they were reclaimed → port exhaustion.

(#609 added `DisposeHttpClient = true` + `Dispose`, which stopped the acute leak but left the per-15s channel **churn** in place — this PR removes the churn at its source.)

## Fix — reuse the channel

A `GrpcChannel` is long-lived and re-establishes its underlying HTTP/2 connection on its own, so tearing it down per failure was the wrong model.

- **Reuse** a single channel. `ConnectAsync` only (re)builds when there is no channel yet, or to **rotate** between multiple configured servers for failover (paced by backoff). A single-server setup — the common/recommended case — reuses **one channel for the whole process → zero churn**.
- **Honest recovery.** Instead of marking `Connected` optimistically, it actively re-probes the reused channel via `GrpcChannel.ConnectAsync` (net6.0+), bounded by `ConnectTimeout`. An unreachable server is reported as `Failure` (circuit stays open, reporters drop-fast) until the probe succeeds.
- **Backoff + re-entrancy guard.** `ConnectService` paces the re-probes with exponential backoff (15s → 5min, reset on connect) and an `Interlocked` guard so the periodic `async void` timer can't stack overlapping probes (which matters because the shipped samples set `ConnectTimeout` well above the 15s tick). It also disposes the channel on agent shutdown, threading the shutdown token into the probe so a long `ConnectTimeout` can't stall graceful stop.

The reporters were already written as a circuit-breaker (`if (!Ready) return; … catch { Failure(ex); }`), so no consumer changes were needed.

## Behavior / compatibility notes

- **netstandard2.0:** `GrpcChannel.ConnectAsync` is absent from the netstandard2.0 asset of `Grpc.Net.Client` (it's gated behind `SUPPORT_LOAD_BALANCING`, net6.0+ only). The active probe is therefore `#if NET6_0_OR_GREATER`-guarded; the netstandard2.0 build keeps the lazy connect but **still reuses the channel**, so it no longer churns either. net8.0/net10.0 get the full probe.
- **Multi-server (`Servers=a,b,c`):** still rotates between endpoints on reconnect (failover preserved), but now paced by backoff and properly disposed instead of churning every 15s. A future enhancement could use gRPC-native client-side load balancing so multi-server also reuses a single channel.

## Verifying the difference

This is a *resource-under-outage* change, not a throughput one — a latency/throughput benchmark shows no delta (both reuse on the happy path). To see it: point the agent at an unreachable OAP (e.g. a closed port) for a few minutes and watch the connection count (`Get-NetTCPConnection -OwningProcess <pid>` on Windows, `ss -tan | grep <port>` on Linux, or `dotnet-counters` on `System.Net.Sockets`). Old: count climbs. New: flat at ~1 (single-server).

Closes #608
