### PR TITLE
fix(core): resolve the exit segment context in SegmentContextAccessor (#552)

### DIFF
--- a/src/SkyApm.Core/Tracing/SegmentContextAccessor.cs
+++ b/src/SkyApm.Core/Tracing/SegmentContextAccessor.cs
@@ -37,6 +37,6 @@ namespace SkyApm.Tracing
         
         public SegmentContext Context =>
             _localSegmentContextAccessor.Context ??
-            _entrySegmentContextAccessor.Context ?? _entrySegmentContextAccessor.Context;
+            _entrySegmentContextAccessor.Context ?? _exitSegmentContextAccessor.Context;
     }
 }

--- a/test/SkyApm.Core.Tests/SegmentContextAccessorTests.cs
+++ b/test/SkyApm.Core.Tests/SegmentContextAccessorTests.cs
@@ -1,0 +1,69 @@
+using SkyApm.Tracing;
+using SkyApm.Tracing.Segments;
+using Xunit;
+
+namespace SkyApm.Core.Tests
+{
+    public class SegmentContextAccessorTests
+    {
+        private static SegmentContext NewContext(string id, SpanType spanType) =>
+            new SegmentContext($"trace-{id}", $"segment-{id}", true, "service", "instance", $"op-{id}", spanType);
+
+        private static (SegmentContextAccessor accessor,
+            IEntrySegmentContextAccessor entry,
+            ILocalSegmentContextAccessor local,
+            IExitSegmentContextAccessor exit) NewAccessor()
+        {
+            var entry = new EntrySegmentContextAccessor();
+            var local = new LocalSegmentContextAccessor();
+            var exit = new ExitSegmentContextAccessor();
+            return (new SegmentContextAccessor(entry, local, exit), entry, local, exit);
+        }
+
+        [Fact]
+        public void Context_Is_Null_When_Nothing_Set()
+        {
+            var (accessor, _, _, _) = NewAccessor();
+            Assert.Null(accessor.Context);
+        }
+
+        // Regression for #552: the exit accessor was injected but never read
+        // (its slot held a duplicate of the entry accessor), so an exit-only
+        // context resolved to null instead of the exit segment.
+        [Fact]
+        public void Context_Returns_Exit_When_Only_Exit_Set()
+        {
+            var (accessor, _, _, exit) = NewAccessor();
+            var exitContext = NewContext("exit", SpanType.Exit);
+            exit.Context = exitContext;
+            Assert.Same(exitContext, accessor.Context);
+        }
+
+        [Fact]
+        public void Context_Returns_Entry_When_Only_Entry_Set()
+        {
+            var (accessor, entry, _, _) = NewAccessor();
+            var entryContext = NewContext("entry", SpanType.Entry);
+            entry.Context = entryContext;
+            Assert.Same(entryContext, accessor.Context);
+        }
+
+        [Fact]
+        public void Context_Prefers_Local_Then_Entry_Then_Exit()
+        {
+            var (accessor, entry, local, exit) = NewAccessor();
+            var entryContext = NewContext("entry", SpanType.Entry);
+            var localContext = NewContext("local", SpanType.Local);
+            var exitContext = NewContext("exit", SpanType.Exit);
+
+            // entry + exit set, no local -> entry wins over exit.
+            entry.Context = entryContext;
+            exit.Context = exitContext;
+            Assert.Same(entryContext, accessor.Context);
+
+            // local set -> local wins over entry and exit.
+            local.Context = localContext;
+            Assert.Same(localContext, accessor.Context);
+        }
+    }
+}


### PR DESCRIPTION
## Problem (#552)

`SegmentContextAccessor` takes `IEntrySegmentContextAccessor`, `ILocalSegmentContextAccessor` **and** `IExitSegmentContextAccessor`, but the exit accessor was **never read** — the fallback chain's third operand was a copy-paste duplicate of the entry accessor:

```csharp
public SegmentContext Context =>
    _localSegmentContextAccessor.Context ??
    _entrySegmentContextAccessor.Context ?? _entrySegmentContextAccessor.Context; // <- exit, not entry
```

So when a segment context is active only on the **exit** accessor (e.g. a standalone outbound call with no entry/local segment), `Context` resolved to `null`, dropping log/trace correlation for that case. The reporter (@saber-wang) spotted exactly this.

History: the duplicate predates the local-first reorder in #548 — the exit operand was simply never wired up.

## Fix

```csharp
public SegmentContext Context =>
    _localSegmentContextAccessor.Context ??
    _entrySegmentContextAccessor.Context ?? _exitSegmentContextAccessor.Context;
```

This keeps the deliberate **local → entry** precedence from #548 and adds **exit** as the final fallback (matching the reporter's suggestion). The precedence is consistent with the factory's own `GetParentSegmentContext` (`local ?? entry`), where an exit span is always a leaf.

> Note on ordering: exit is intentionally the *last* fallback, so in the common nested case (entry/local still active during an outbound call) correlation stays on the entry/local segment as before; exit only surfaces when it's the sole active context. If we instead wanted logs emitted *during* an exit span to correlate to the exit segment, the order would be `exit ?? local ?? entry` — a behavioral change to log correlation. Happy to switch if that's the intended semantics.

## Test

Adds `SegmentContextAccessorTests` covering the precedence and the exit-only regression (the `Context_Returns_Exit_When_Only_Exit_Set` case fails on the old code, passes on the fix).

Fixes #552
