### PR TITLE
fix(efcore): recognise MySqlConnector for Pomelo MySQL exit spans (#536)

### DIFF
--- a/src/SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql/MySqlEntityFrameworkCoreSpanMetadataProvider.cs
+++ b/src/SkyApm.Diagnostics.EntityFrameworkCore.Pomelo.MySql/MySqlEntityFrameworkCoreSpanMetadataProvider.cs
@@ -35,7 +35,12 @@ namespace SkyApm.Diagnostics.EntityFrameworkCore
         
         public bool Match(DbConnection connection)
         {
-            return connection.GetType().FullName == "MySql.Data.MySqlClient.MySqlConnection";
+            // Pomelo.EntityFrameworkCore.MySql switched to MySqlConnector in its 3.0 release; older
+            // 2.x versions used MySql.Data. Match both so the command is recorded as an exit span
+            // (required for virtual-database detection). Mirrors MySqlConnectorPeerFormatter. (#536)
+            var fullName = connection.GetType().FullName;
+            return fullName == "MySql.Data.MySqlClient.MySqlConnection"
+                || fullName == "MySqlConnector.MySqlConnection";
         }
 
         public string GetPeer(DbConnection connection)


### PR DESCRIPTION
## Question/bug (#536)

`MySqlEntityFrameworkCoreSpanMetadataProvider` (for **Pomelo.EntityFrameworkCore.MySql**) only marks a command as an **exit** span when the connection type is `MySql.Data.MySqlClient.MySqlConnection`:

```csharp
public bool Match(DbConnection connection) =>
    connection.GetType().FullName == "MySql.Data.MySqlClient.MySqlConnection";
```

But **Pomelo switched to [MySqlConnector](https://mysqlconnector.net/) in its 3.0 release**, so on any modern Pomelo the connection is `MySqlConnector.MySqlConnection`. `Match` therefore returns `false`, and `EntityFrameworkCoreSegmentContextFactory.Create` falls back to a **local** span instead of an exit span — which breaks virtual-database detection (the reporter's exact point: the virtual database requires the span to be exit).

## Fix

Match both connector type names — exactly mirroring [`MySqlConnectorPeerFormatter.Match`](src/SkyApm.PeerFormatters.MySqlConnector/MySqlConnectorPeerFormatter.cs#L33), which already recognises both:

```csharp
var fullName = connection.GetType().FullName;
return fullName == "MySql.Data.MySqlClient.MySqlConnection"
    || fullName == "MySqlConnector.MySqlConnection";
```

This fixes modern Pomelo (MySqlConnector) while keeping old Pomelo 2.x (MySql.Data) working. The peer-formatter side already handles MySqlConnector, so only the metadata provider's `Match` needed updating.

> No unit test added: exercising `Match` needs a `DbConnection` stub whose runtime `GetType().FullName` equals each target string (a sizeable abstract-class stub + a new project reference), which is disproportionate for a one-line string match that mirrors existing code. Happy to add one if preferred.

Fixes #536
