### PR TITLE
docs(readme): replace dead QQ groups with Slack join instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ See [Contributing to SkyAPM-dotnet](./CONTRIBUTING.md).
 For questions about the **SkyWalking protocol or its backend/UI**, use the official Apache SkyWalking channels (these are not suitable for the .NET agent):
 * Submit an official Apache SkyWalking [issue](https://github.com/apache/skywalking/issues).
 * Mail list: **dev@skywalking.apache.org**. Mail to `dev-subscribe@skywalking.apache.org`, follow the reply to subscribe the mail list.
-* Join the `skywalking` channel at [Apache Slack](https://join.slack.com/t/the-asf/shared_invite/enQtNzc2ODE3MjI1MDk1LTAyZGJmNTg1NWZhNmVmOWZjMjA2MGUyOGY4MjE5ZGUwOTQxY2Q3MDBmNTM5YTllNGU4M2QyMzQ4M2U4ZjQ5YmY). If the link is not working, find the latest one at the [Apache INFRA WIKI](https://cwiki.apache.org/confluence/display/INFRA/Slack+Guest+Invites).
-* QQ Group: 392443393(2000/2000, not available), 901167865(available)
+* Send `Request to join SkyWalking slack` mail to the mail list (`dev@skywalking.apache.org`), we will invite you in.
+* For Chinese speaker, send `[CN] Request to join SkyWalking slack` mail to the mail list (`dev@skywalking.apache.org`), we will invite you in.
 
 ## License
 


### PR DESCRIPTION
The README's Contact Us section still listed two QQ groups, both gone: `392443393` is full (2000/2000) and `901167865` is no longer available.

Replace them with the same Slack guidance the Apache SkyWalking README uses today — request an invite via the dev mail list, with a dedicated line for Chinese speakers (the audience the QQ groups served). Also drops the stale hard-coded Slack invite link in favour of the upstream mail-request flow.

Mirrors `apache/skywalking` README's *Contact Us* section.