### PR TITLE
fix(core): stop diagnostic log spam on instrumented-library version mismatch (#565)

### DIFF
--- a/src/SkyApm.Core/Diagnostics/TracingDiagnosticObserver.cs
+++ b/src/SkyApm.Core/Diagnostics/TracingDiagnosticObserver.cs
@@ -17,6 +17,7 @@
  */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using SkyApm.Logging;
@@ -26,6 +27,7 @@ namespace SkyApm.Diagnostics
     internal class TracingDiagnosticObserver : IObserver<KeyValuePair<string, object>>
     {
         private readonly Dictionary<string, TracingDiagnosticMethod> _methodCollection;
+        private readonly ConcurrentDictionary<string, byte> _disabledDiagnostics = new ConcurrentDictionary<string, byte>();
         private readonly ILogger _logger;
 
         public TracingDiagnosticObserver(ITracingDiagnosticProcessor tracingDiagnosticProcessor,
@@ -54,9 +56,25 @@ namespace SkyApm.Diagnostics
             if (!_methodCollection.TryGetValue(value.Key, out var method))
                 return;
 
+            if (_disabledDiagnostics.ContainsKey(value.Key))
+                return;
+
             try
             {
                 method.Invoke(value.Key, value.Value);
+            }
+            catch (Exception exception) when (exception is MissingMemberException || exception is TypeLoadException)
+            {
+                // A binding/structural error means the instrumented library's version is incompatible
+                // with this plugin (e.g. a diagnostic event type or property changed across versions).
+                // It fails deterministically for every event, so disable this handler after logging once
+                // instead of spamming the same error on every call (issue #565).
+                if (_disabledDiagnostics.TryAdd(value.Key, 0))
+                {
+                    _logger.Warning($"Disabled diagnostic handler '{value.Key}' due to an incompatible " +
+                                    "instrumented library version; ensure the installed package version matches " +
+                                    $"this SkyAPM plugin. {exception.GetType().Name}: {exception.Message}");
+                }
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
## Bug (#565)

`SkyApm.Diagnostics.CAP` (and any plugin) is compiled against a specific version of the library it instruments, but NuGet unifies that library to the **user's** installed version. When the user's `DotNetCore.CAP` differs in a binary-breaking way (the reporter had CAP 7.1.4 vs the plugin's 7.0.1), the handler throws:

```
System.MissingMethodException: Method not found:
'DotNetCore.CAP.Messages.TransportMessage DotNetCore.CAP.Diagnostics.CapEventDataPubSend.get_TransportMessage()'
   at SkyApm.Diagnostics.CAP.CapTracingDiagnosticProcessor.BeforePublish(...)
   at SkyApm.Diagnostics.TracingDiagnosticObserver.OnNext(...)
```

`TracingDiagnosticObserver.OnNext` already caught the exception (so CAP keeps working), but it **re-logged the same error on every publish/consume event** — endless `Invoke diagnostic method exception.` spam that "never recovers" (the reporter's words), because a `MissingMethodException` is deterministic and re-throws every time.

## Fix

Treat structural binding failures (`MissingMemberException` — which covers `MissingMethodException`/`MissingFieldException` — and `TypeLoadException`) as **permanent**: log a single clear warning with a version-match hint, then **disable that diagnostic handler** so it stops firing and spamming.

```csharp
if (_disabledDiagnostics.ContainsKey(value.Key)) return;
try { method.Invoke(value.Key, value.Value); }
catch (Exception ex) when (ex is MissingMemberException || ex is TypeLoadException)
{
    if (_disabledDiagnostics.TryAdd(value.Key, 0))
        _logger.Warning($"Disabled diagnostic handler '{value.Key}' due to an incompatible " +
                        "instrumented library version; ensure the installed package version matches " +
                        $"this SkyAPM plugin. {ex.GetType().Name}: {ex.Message}");
}
catch (Exception ex) { _logger.Error("Invoke diagnostic method exception.", ex); }
```

- General (helps every diagnostic plugin, not just CAP), thread-safe (`ConcurrentDictionary`, warning logged exactly once), and leaves the happy path untouched.
- Transient exceptions keep their existing per-occurrence `Error` logging.
- The underlying coupling (plugin must match the instrumented library's major version) is real and will be covered by upcoming plugin-development/testing docs.

Fixes #565