### PR TITLE
docs(transports): document TLS via an https:// gRPC server address (#521)

### DIFF
--- a/content/docs/guides/transports.md
+++ b/content/docs/guides/transports.md
@@ -124,6 +124,25 @@ leaves them untouched:
 }
 ```
 
+### TLS / SSL
+
+Because the `http://` prefix is only added when the address has no scheme, giving an
+explicit **`https://`** address makes the agent connect to OAP over **TLS** — point it
+at the OAP's TLS gRPC port:
+
+```json
+{
+  "SkyWalking:Transport:gRPC:Servers": "https://your-oap-host:443"
+}
+```
+
+The server certificate is validated against the host's trust store (system CA roots),
+so this works out of the box for certificates issued by a trusted CA. There is
+currently **no** option for a custom / self-signed CA or for mutual (client) TLS —
+those would require a custom `HttpClientHandler`, which the agent does not expose
+today. (`Authentication`, below, is unrelated to TLS — it is an application token
+sent as gRPC metadata.)
+
 ### Authentication
 
 If the OAP backend has token authentication enabled, set `Authentication` to the


### PR DESCRIPTION
[#521](https://github.com/SkyAPM/SkyAPM-dotnet/issues/521) asked how to enable SSL/TLS in `skyapm.json`. It already works — the agent only auto-prefixes `http://` when the address has no scheme, so an explicit `https://` server address makes the gRPC channel use TLS — but `transports.md` never said so.

Adds a **TLS / SSL** subsection to the gRPC transport docs:
- `Servers: "https://your-oap-host:443"` connects over TLS (server cert validated against the system CA store).
- Notes that custom/self-signed CA and mutual TLS aren't configurable today (would need a custom `HttpClientHandler`), and that `Authentication` is unrelated to TLS.

Docs-only.